### PR TITLE
[FEAT] ScreenTime, UserProfile API 구현 

### DIFF
--- a/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
+++ b/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 		BF2FE0262B64CBC9009C3C73 /* ScreenTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2FE0252B64CBC9009C3C73 /* ScreenTime.swift */; };
 		BF6B12DC2B64B9170031165E /* ScreenTimeInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6B12DB2B64B9170031165E /* ScreenTimeInputViewController.swift */; };
 		BF6B12DE2B64B9B40031165E /* CustomUISlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6B12DD2B64B9B40031165E /* CustomUISlider.swift */; };
+		BF7181D12B7358CA00ACEA0D /* CategoryDurationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181D02B7358C900ACEA0D /* CategoryDurationRequest.swift */; };
+		BF7181D42B749EC400ACEA0D /* ScreenTimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181D32B749EC400ACEA0D /* ScreenTimeService.swift */; };
+		BF7181D62B74A0F800ACEA0D /* CategoryDurationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181D52B74A0F800ACEA0D /* CategoryDurationResponse.swift */; };
+		BF7181D82B74A13100ACEA0D /* ScreenTimeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181D72B74A13100ACEA0D /* ScreenTimeAPI.swift */; };
 		BF7209BD2B5F8BCB001D76CB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7209BC2B5F8BCB001D76CB /* SceneDelegate.swift */; };
 		BF7209BF2B5F8BCB001D76CB /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7209BE2B5F8BCB001D76CB /* MainViewController.swift */; };
 		BF7209C42B5F8BCD001D76CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF7209C32B5F8BCD001D76CB /* Assets.xcassets */; };
@@ -94,6 +98,10 @@
 		BF2FE0252B64CBC9009C3C73 /* ScreenTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTime.swift; sourceTree = "<group>"; };
 		BF6B12DB2B64B9170031165E /* ScreenTimeInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeInputViewController.swift; sourceTree = "<group>"; };
 		BF6B12DD2B64B9B40031165E /* CustomUISlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomUISlider.swift; sourceTree = "<group>"; };
+		BF7181D02B7358C900ACEA0D /* CategoryDurationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDurationRequest.swift; sourceTree = "<group>"; };
+		BF7181D32B749EC400ACEA0D /* ScreenTimeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeService.swift; sourceTree = "<group>"; };
+		BF7181D52B74A0F800ACEA0D /* CategoryDurationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDurationResponse.swift; sourceTree = "<group>"; };
+		BF7181D72B74A13100ACEA0D /* ScreenTimeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeAPI.swift; sourceTree = "<group>"; };
 		BF7209B72B5F8BCB001D76CB /* Wetox-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Wetox-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF7209BA2B5F8BCB001D76CB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BF7209BC2B5F8BCB001D76CB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -158,6 +166,7 @@
 		5514CE5B2B65F6F8006B2700 /* NetworkService */ = {
 			isa = PBXGroup;
 			children = (
+				BF7181D22B749EA800ACEA0D /* ScreenTime */,
 				5514CE622B65F87F006B2700 /* Plugin */,
 				5514CE5C2B65F704006B2700 /* Auth */,
 			);
@@ -184,6 +193,7 @@
 		554F273E2B638ECF0050B6D9 /* NetworkModel */ = {
 			isa = PBXGroup;
 			children = (
+				BF7181CF2B73588800ACEA0D /* ScreenTime */,
 				554F27442B6390BE0050B6D9 /* Auth */,
 				5514CE652B65F91F006B2700 /* NetworkResult.swift */,
 				558601972B6629A6007EA357 /* Const.swift */,
@@ -235,6 +245,24 @@
 				BF6B12DD2B64B9B40031165E /* CustomUISlider.swift */,
 			);
 			path = ScreenTimeInputView;
+			sourceTree = "<group>";
+		};
+		BF7181CF2B73588800ACEA0D /* ScreenTime */ = {
+			isa = PBXGroup;
+			children = (
+				BF7181D02B7358C900ACEA0D /* CategoryDurationRequest.swift */,
+				BF7181D52B74A0F800ACEA0D /* CategoryDurationResponse.swift */,
+			);
+			path = ScreenTime;
+			sourceTree = "<group>";
+		};
+		BF7181D22B749EA800ACEA0D /* ScreenTime */ = {
+			isa = PBXGroup;
+			children = (
+				BF7181D32B749EC400ACEA0D /* ScreenTimeService.swift */,
+				BF7181D72B74A13100ACEA0D /* ScreenTimeAPI.swift */,
+			);
+			path = ScreenTime;
 			sourceTree = "<group>";
 		};
 		BF7209AE2B5F8BCB001D76CB = {
@@ -501,7 +529,10 @@
 				BFB317AC2B6693A4007F0A9A /* View+Extension.swift in Sources */,
 				552FE1742B6118DE00A4F568 /* ProfileSettingViewContorller.swift in Sources */,
 				556AA2D02B6A3B2B00F2AE79 /* TextField+Extension.swift in Sources */,
+				BF7181D12B7358CA00ACEA0D /* CategoryDurationRequest.swift in Sources */,
+				BF7181D82B74A13100ACEA0D /* ScreenTimeAPI.swift in Sources */,
 				BF0EBDDF2B6529D000AEF19D /* AppDelegate.swift in Sources */,
+				BF7181D62B74A0F800ACEA0D /* CategoryDurationResponse.swift in Sources */,
 				BFB317A82B666962007F0A9A /* ScreenTimeInputViewModel.swift in Sources */,
 				BFB317A52B6666AF007F0A9A /* TimeConverter.swift in Sources */,
 				BFB317A32B665744007F0A9A /* StrokeLabel.swift in Sources */,
@@ -513,6 +544,7 @@
 				BFB317AA2B669358007F0A9A /* BottomSheetView.swift in Sources */,
 				BF7209BD2B5F8BCB001D76CB /* SceneDelegate.swift in Sources */,
 				554F27492B6391E20050B6D9 /* RegisterResponse.swift in Sources */,
+				BF7181D42B749EC400ACEA0D /* ScreenTimeService.swift in Sources */,
 				557F3EA22B60983A007C7247 /* Button+Extension.swift in Sources */,
 				554F27412B638EE60050B6D9 /* TokenRequest.swift in Sources */,
 				5514CE602B65F721006B2700 /* AuthService.swift in Sources */,

--- a/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
+++ b/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
@@ -41,8 +41,8 @@
 		BF7181DA2B78E4DD00ACEA0D /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181D92B78E4DD00ACEA0D /* MainViewModel.swift */; };
 		BF7181DD2B7A2EB300ACEA0D /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181DC2B7A2EB300ACEA0D /* UserService.swift */; };
 		BF7181DF2B7A2EBB00ACEA0D /* UserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181DE2B7A2EBB00ACEA0D /* UserAPI.swift */; };
-		BF7181E22B7A2F7D00ACEA0D /* UserRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181E12B7A2F7D00ACEA0D /* UserRequest.swift */; };
 		BF7181E42B7A2F8900ACEA0D /* UserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181E32B7A2F8900ACEA0D /* UserResponse.swift */; };
+		BF7181E62B7B56D600ACEA0D /* DateFormatter+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181E52B7B56D600ACEA0D /* DateFormatter+Extension.swift */; };
 		BF7209BD2B5F8BCB001D76CB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7209BC2B5F8BCB001D76CB /* SceneDelegate.swift */; };
 		BF7209BF2B5F8BCB001D76CB /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7209BE2B5F8BCB001D76CB /* MainViewController.swift */; };
 		BF7209C42B5F8BCD001D76CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF7209C32B5F8BCD001D76CB /* Assets.xcassets */; };
@@ -110,8 +110,8 @@
 		BF7181D92B78E4DD00ACEA0D /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		BF7181DC2B7A2EB300ACEA0D /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
 		BF7181DE2B7A2EBB00ACEA0D /* UserAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPI.swift; sourceTree = "<group>"; };
-		BF7181E12B7A2F7D00ACEA0D /* UserRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRequest.swift; sourceTree = "<group>"; };
 		BF7181E32B7A2F8900ACEA0D /* UserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponse.swift; sourceTree = "<group>"; };
+		BF7181E52B7B56D600ACEA0D /* DateFormatter+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extension.swift"; sourceTree = "<group>"; };
 		BF7209B72B5F8BCB001D76CB /* Wetox-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Wetox-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF7209BA2B5F8BCB001D76CB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BF7209BC2B5F8BCB001D76CB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -289,7 +289,6 @@
 		BF7181E02B7A2F6E00ACEA0D /* User */ = {
 			isa = PBXGroup;
 			children = (
-				BF7181E12B7A2F7D00ACEA0D /* UserRequest.swift */,
 				BF7181E32B7A2F8900ACEA0D /* UserResponse.swift */,
 			);
 			path = User;
@@ -361,6 +360,7 @@
 				557F3EA12B60983A007C7247 /* Button+Extension.swift */,
 				BFB317AB2B6693A4007F0A9A /* View+Extension.swift */,
 				556AA2CF2B6A3B2B00F2AE79 /* TextField+Extension.swift */,
+				BF7181E52B7B56D600ACEA0D /* DateFormatter+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -552,7 +552,6 @@
 			files = (
 				BF7209EE2B5F8CB6001D76CB /* Label+Extension.swift in Sources */,
 				5514CE5E2B65F719006B2700 /* AuthAPI.swift in Sources */,
-				BF7181E22B7A2F7D00ACEA0D /* UserRequest.swift in Sources */,
 				554F27472B6391D80050B6D9 /* RegisterRequest.swift in Sources */,
 				5514CE662B65F91F006B2700 /* NetworkResult.swift in Sources */,
 				BF7209F52B5F923F001D76CB /* FriendsCollectionViewCell.swift in Sources */,
@@ -565,6 +564,7 @@
 				BF7181D82B74A13100ACEA0D /* ScreenTimeAPI.swift in Sources */,
 				BF7181E42B7A2F8900ACEA0D /* UserResponse.swift in Sources */,
 				BF0EBDDF2B6529D000AEF19D /* AppDelegate.swift in Sources */,
+				BF7181E62B7B56D600ACEA0D /* DateFormatter+Extension.swift in Sources */,
 				BF7181D62B74A0F800ACEA0D /* CategoryDurationResponse.swift in Sources */,
 				BFB317A82B666962007F0A9A /* ScreenTimeInputViewModel.swift in Sources */,
 				BFB317A52B6666AF007F0A9A /* TimeConverter.swift in Sources */,

--- a/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
+++ b/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
@@ -38,6 +38,11 @@
 		BF7181D42B749EC400ACEA0D /* ScreenTimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181D32B749EC400ACEA0D /* ScreenTimeService.swift */; };
 		BF7181D62B74A0F800ACEA0D /* CategoryDurationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181D52B74A0F800ACEA0D /* CategoryDurationResponse.swift */; };
 		BF7181D82B74A13100ACEA0D /* ScreenTimeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181D72B74A13100ACEA0D /* ScreenTimeAPI.swift */; };
+		BF7181DA2B78E4DD00ACEA0D /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181D92B78E4DD00ACEA0D /* MainViewModel.swift */; };
+		BF7181DD2B7A2EB300ACEA0D /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181DC2B7A2EB300ACEA0D /* UserService.swift */; };
+		BF7181DF2B7A2EBB00ACEA0D /* UserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181DE2B7A2EBB00ACEA0D /* UserAPI.swift */; };
+		BF7181E22B7A2F7D00ACEA0D /* UserRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181E12B7A2F7D00ACEA0D /* UserRequest.swift */; };
+		BF7181E42B7A2F8900ACEA0D /* UserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7181E32B7A2F8900ACEA0D /* UserResponse.swift */; };
 		BF7209BD2B5F8BCB001D76CB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7209BC2B5F8BCB001D76CB /* SceneDelegate.swift */; };
 		BF7209BF2B5F8BCB001D76CB /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7209BE2B5F8BCB001D76CB /* MainViewController.swift */; };
 		BF7209C42B5F8BCD001D76CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF7209C32B5F8BCD001D76CB /* Assets.xcassets */; };
@@ -102,6 +107,11 @@
 		BF7181D32B749EC400ACEA0D /* ScreenTimeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeService.swift; sourceTree = "<group>"; };
 		BF7181D52B74A0F800ACEA0D /* CategoryDurationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDurationResponse.swift; sourceTree = "<group>"; };
 		BF7181D72B74A13100ACEA0D /* ScreenTimeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeAPI.swift; sourceTree = "<group>"; };
+		BF7181D92B78E4DD00ACEA0D /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
+		BF7181DC2B7A2EB300ACEA0D /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
+		BF7181DE2B7A2EBB00ACEA0D /* UserAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPI.swift; sourceTree = "<group>"; };
+		BF7181E12B7A2F7D00ACEA0D /* UserRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRequest.swift; sourceTree = "<group>"; };
+		BF7181E32B7A2F8900ACEA0D /* UserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponse.swift; sourceTree = "<group>"; };
 		BF7209B72B5F8BCB001D76CB /* Wetox-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Wetox-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF7209BA2B5F8BCB001D76CB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BF7209BC2B5F8BCB001D76CB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -166,6 +176,7 @@
 		5514CE5B2B65F6F8006B2700 /* NetworkService */ = {
 			isa = PBXGroup;
 			children = (
+				BF7181DB2B7A2EA500ACEA0D /* User */,
 				BF7181D22B749EA800ACEA0D /* ScreenTime */,
 				5514CE622B65F87F006B2700 /* Plugin */,
 				5514CE5C2B65F704006B2700 /* Auth */,
@@ -193,6 +204,7 @@
 		554F273E2B638ECF0050B6D9 /* NetworkModel */ = {
 			isa = PBXGroup;
 			children = (
+				BF7181E02B7A2F6E00ACEA0D /* User */,
 				BF7181CF2B73588800ACEA0D /* ScreenTime */,
 				554F27442B6390BE0050B6D9 /* Auth */,
 				5514CE652B65F91F006B2700 /* NetworkResult.swift */,
@@ -263,6 +275,24 @@
 				BF7181D72B74A13100ACEA0D /* ScreenTimeAPI.swift */,
 			);
 			path = ScreenTime;
+			sourceTree = "<group>";
+		};
+		BF7181DB2B7A2EA500ACEA0D /* User */ = {
+			isa = PBXGroup;
+			children = (
+				BF7181DC2B7A2EB300ACEA0D /* UserService.swift */,
+				BF7181DE2B7A2EBB00ACEA0D /* UserAPI.swift */,
+			);
+			path = User;
+			sourceTree = "<group>";
+		};
+		BF7181E02B7A2F6E00ACEA0D /* User */ = {
+			isa = PBXGroup;
+			children = (
+				BF7181E12B7A2F7D00ACEA0D /* UserRequest.swift */,
+				BF7181E32B7A2F8900ACEA0D /* UserResponse.swift */,
+			);
+			path = User;
 			sourceTree = "<group>";
 		};
 		BF7209AE2B5F8BCB001D76CB = {
@@ -362,6 +392,7 @@
 			isa = PBXGroup;
 			children = (
 				BFB317A72B666962007F0A9A /* ScreenTimeInputViewModel.swift */,
+				BF7181D92B78E4DD00ACEA0D /* MainViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -521,6 +552,7 @@
 			files = (
 				BF7209EE2B5F8CB6001D76CB /* Label+Extension.swift in Sources */,
 				5514CE5E2B65F719006B2700 /* AuthAPI.swift in Sources */,
+				BF7181E22B7A2F7D00ACEA0D /* UserRequest.swift in Sources */,
 				554F27472B6391D80050B6D9 /* RegisterRequest.swift in Sources */,
 				5514CE662B65F91F006B2700 /* NetworkResult.swift in Sources */,
 				BF7209F52B5F923F001D76CB /* FriendsCollectionViewCell.swift in Sources */,
@@ -531,19 +563,23 @@
 				556AA2D02B6A3B2B00F2AE79 /* TextField+Extension.swift in Sources */,
 				BF7181D12B7358CA00ACEA0D /* CategoryDurationRequest.swift in Sources */,
 				BF7181D82B74A13100ACEA0D /* ScreenTimeAPI.swift in Sources */,
+				BF7181E42B7A2F8900ACEA0D /* UserResponse.swift in Sources */,
 				BF0EBDDF2B6529D000AEF19D /* AppDelegate.swift in Sources */,
 				BF7181D62B74A0F800ACEA0D /* CategoryDurationResponse.swift in Sources */,
 				BFB317A82B666962007F0A9A /* ScreenTimeInputViewModel.swift in Sources */,
 				BFB317A52B6666AF007F0A9A /* TimeConverter.swift in Sources */,
 				BFB317A32B665744007F0A9A /* StrokeLabel.swift in Sources */,
+				BF7181DF2B7A2EBB00ACEA0D /* UserAPI.swift in Sources */,
 				BF7209BF2B5F8BCB001D76CB /* MainViewController.swift in Sources */,
 				558601982B6629A6007EA357 /* Const.swift in Sources */,
 				554412902B608CA9001B8CBA /* LoginViewController.swift in Sources */,
 				5514CE642B65F891006B2700 /* MoyaLoggerPlugin.swift in Sources */,
+				BF7181DD2B7A2EB300ACEA0D /* UserService.swift in Sources */,
 				BF7209F72B5F926B001D76CB /* CircularProgressBar.swift in Sources */,
 				BFB317AA2B669358007F0A9A /* BottomSheetView.swift in Sources */,
 				BF7209BD2B5F8BCB001D76CB /* SceneDelegate.swift in Sources */,
 				554F27492B6391E20050B6D9 /* RegisterResponse.swift in Sources */,
+				BF7181DA2B78E4DD00ACEA0D /* MainViewModel.swift in Sources */,
 				BF7181D42B749EC400ACEA0D /* ScreenTimeService.swift in Sources */,
 				557F3EA22B60983A007C7247 /* Button+Extension.swift in Sources */,
 				554F27412B638EE60050B6D9 /* TokenRequest.swift in Sources */,

--- a/Wetox-iOS/Wetox-iOS/Extension/DateFormatter+Extension.swift
+++ b/Wetox-iOS/Wetox-iOS/Extension/DateFormatter+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  DateFormatter+Extension.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/13/24.
+//
+
+import Foundation
+
+extension DateFormatter {
+    func mapDateFormat() -> DateFormatter {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return dateFormatter
+    }
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/ScreenTime/CategoryDurationRequest.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/ScreenTime/CategoryDurationRequest.swift
@@ -1,0 +1,13 @@
+//
+//  ScreenTimeRequest.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/7/24.
+//
+
+import Foundation
+
+struct CategoryDurationRequest: Codable {
+    let category: String
+    let duration: Int
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/ScreenTime/CategoryDurationResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/ScreenTime/CategoryDurationResponse.swift
@@ -1,0 +1,15 @@
+//
+//  CategoryDurationResponse.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/8/24.
+//
+
+import Foundation
+
+struct CategoryDurationResponse: Codable {
+    let nickname: String
+    let updatedDate: Date
+    let totalDuration: Int
+    let categoryScreenTimes: [CategoryDurationRequest]
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/User/UserResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/User/UserResponse.swift
@@ -1,0 +1,14 @@
+//
+//  UserResponse.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/12/24.
+//
+
+import Foundation
+
+struct UserResponse: Codable {
+    let userId: Int64
+    let nickname: String
+    let profileImage: String
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeAPI.swift
@@ -14,12 +14,13 @@ import RxMoya
 class ScreenTimeAPI {
     static let provider = MoyaProvider<ScreenTimeService>(plugins: [MoyaLoggerPlugin()])
     
+    
     /// CategoryDuration 데이터를 post 요청
     static func postCategoryDuration(data: [CategoryDurationRequest]) -> Observable<CategoryDurationResponse> {
         
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        
+        decoder.dateDecodingStrategy = .formatted(DateFormatter().mapDateFormat())
+
         return provider.rx.request(.postCategoryDuration(data: data))
             .map(CategoryDurationResponse.self, using: decoder)
             .asObservable()
@@ -27,24 +28,22 @@ class ScreenTimeAPI {
                 if let moyaError = error as? MoyaError {
                     switch moyaError {
                     case .statusCode(let response):
-                        // HTTP 상태 코드에 따른 처리
                         print("HTTP Status Code: \(response.statusCode)")
                     case .jsonMapping(let response):
-                        // JSON 매핑 에러 처리
                         print("JSON Mapping Error for Response: \(response)")
                     default:
-                        // 기타 Moya 에러 처리
                         print("Other MoyaError: \(moyaError.localizedDescription)")
                     }
                 }
-                return Observable.error(error) // 원래의 에러를 다시 방출
+                return Observable.error(error)
             }
     }
     
     /// /screentime .get 요청
     static func getScreenTime() -> Observable<CategoryDurationResponse> {
+        
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .formatted(DateFormatter().mapDateFormat())
         
         return provider.rx.request(.getScreenTime)
             .map(CategoryDurationResponse.self, using: decoder)
@@ -53,13 +52,34 @@ class ScreenTimeAPI {
                 if let moyaError = error as? MoyaError {
                     switch moyaError {
                         case .statusCode(let response):
-                            // HTTP 상태 코드에 따른 처리
                             print("HTTP Status Code: \(response.statusCode)")
                         case .jsonMapping(let response):
-                            // JSON 매핑 에러 처리
                             print("JSON Mapping Error for Response: \(response)")
                         default:
-                            // 기타 Moya 에러 처리
+                            print("Other MoyaError: \(moyaError.localizedDescription)")
+                    }
+                }
+                return Observable.error(error)
+            }
+    }
+    
+    /// userId를 입력받아 CategoryDurationResponse 타입으로 해당 유저의 스크린타임 사용량을 반환합니다.
+    static func getUserScreenTime(userId: String) -> Observable<CategoryDurationResponse> {
+        
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter().mapDateFormat())
+
+        return provider.rx.request(.getUserScreenTime(userId: userId))
+            .map(CategoryDurationResponse.self, using: decoder)
+            .asObservable()
+            .catch { error in
+                if let moyaError = error as? MoyaError {
+                    switch moyaError {
+                        case .statusCode(let response):
+                            print("HTTP Status Code: \(response.statusCode)")
+                        case .jsonMapping(let response):
+                            print("JSON Mapping Error for Response: \(response)")
+                        default:
                             print("Other MoyaError: \(moyaError.localizedDescription)")
                     }
                 }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeAPI.swift
@@ -40,4 +40,30 @@ class ScreenTimeAPI {
                 return Observable.error(error) // 원래의 에러를 다시 방출
             }
     }
+    
+    /// /screentime .get 요청
+    static func getScreenTime() -> Observable<CategoryDurationResponse> {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        
+        return provider.rx.request(.getScreenTime)
+            .map(CategoryDurationResponse.self, using: decoder)
+            .asObservable()
+            .catch { error in
+                if let moyaError = error as? MoyaError {
+                    switch moyaError {
+                        case .statusCode(let response):
+                            // HTTP 상태 코드에 따른 처리
+                            print("HTTP Status Code: \(response.statusCode)")
+                        case .jsonMapping(let response):
+                            // JSON 매핑 에러 처리
+                            print("JSON Mapping Error for Response: \(response)")
+                        default:
+                            // 기타 Moya 에러 처리
+                            print("Other MoyaError: \(moyaError.localizedDescription)")
+                    }
+                }
+                return Observable.error(error)
+            }
+    }
 }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeAPI.swift
@@ -1,0 +1,43 @@
+//
+//  ScreenTimeAPI.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/8/24.
+//
+
+import Foundation
+
+import Moya
+import RxSwift
+import RxMoya
+
+class ScreenTimeAPI {
+    static let provider = MoyaProvider<ScreenTimeService>(plugins: [MoyaLoggerPlugin()])
+    
+    /// CategoryDuration 데이터를 post 요청
+    static func postCategoryDuration(data: [CategoryDurationRequest]) -> Observable<CategoryDurationResponse> {
+        
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        
+        return provider.rx.request(.postCategoryDuration(data: data))
+            .map(CategoryDurationResponse.self, using: decoder)
+            .asObservable()
+            .catch { error in
+                if let moyaError = error as? MoyaError {
+                    switch moyaError {
+                    case .statusCode(let response):
+                        // HTTP 상태 코드에 따른 처리
+                        print("HTTP Status Code: \(response.statusCode)")
+                    case .jsonMapping(let response):
+                        // JSON 매핑 에러 처리
+                        print("JSON Mapping Error for Response: \(response)")
+                    default:
+                        // 기타 Moya 에러 처리
+                        print("Other MoyaError: \(moyaError.localizedDescription)")
+                    }
+                }
+                return Observable.error(error) // 원래의 에러를 다시 방출
+            }
+    }
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeService.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum ScreenTimeService {
     case postCategoryDuration(data: [CategoryDurationRequest])
+    case getScreenTime
 }
 
 extension ScreenTimeService: TargetType {
@@ -19,7 +20,7 @@ extension ScreenTimeService: TargetType {
     
     var path: String {
         switch self {
-            case .postCategoryDuration:
+            case .postCategoryDuration, .getScreenTime:
                 return "/screentime"
         }
     }
@@ -28,6 +29,8 @@ extension ScreenTimeService: TargetType {
         switch self {
             case .postCategoryDuration:
                 return .post
+            case .getScreenTime:
+                return .get
         }
     }
     
@@ -35,6 +38,8 @@ extension ScreenTimeService: TargetType {
         switch self {
             case .postCategoryDuration(let data):
                 return .requestJSONEncodable(data)
+            case .getScreenTime:
+                return .requestPlain
         }
     }
     

--- a/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeService.swift
@@ -1,0 +1,47 @@
+//
+//  ScreenTimeService.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/8/24.
+//
+
+import Foundation
+import Moya
+
+enum ScreenTimeService {
+    case postCategoryDuration(data: [CategoryDurationRequest])
+}
+
+extension ScreenTimeService: TargetType {
+    var baseURL: URL {
+        return URL(string: Const.URL.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+            case .postCategoryDuration:
+                return "/screentime"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+            case .postCategoryDuration:
+                return .post
+        }
+    }
+    
+    var task: Task {
+        switch self {
+            case .postCategoryDuration(let data):
+                return .requestJSONEncodable(data)
+        }
+    }
+    
+    var headers: [String: String]? {
+        guard let accessToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) else {
+            return nil
+        }
+        return ["Content-Type": "application/json", "Authorization": "Bearer \(accessToken)"]
+    }
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/ScreenTime/ScreenTimeService.swift
@@ -11,6 +11,7 @@ import Moya
 enum ScreenTimeService {
     case postCategoryDuration(data: [CategoryDurationRequest])
     case getScreenTime
+    case getUserScreenTime(userId: String)
 }
 
 extension ScreenTimeService: TargetType {
@@ -22,6 +23,8 @@ extension ScreenTimeService: TargetType {
         switch self {
             case .postCategoryDuration, .getScreenTime:
                 return "/screentime"
+            case .getUserScreenTime(let userId):
+                return "/screentime/\(userId)"
         }
     }
     
@@ -29,7 +32,7 @@ extension ScreenTimeService: TargetType {
         switch self {
             case .postCategoryDuration:
                 return .post
-            case .getScreenTime:
+            case .getScreenTime, .getUserScreenTime:
                 return .get
         }
     }
@@ -38,7 +41,7 @@ extension ScreenTimeService: TargetType {
         switch self {
             case .postCategoryDuration(let data):
                 return .requestJSONEncodable(data)
-            case .getScreenTime:
+            case .getScreenTime, .getUserScreenTime:
                 return .requestPlain
         }
     }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
@@ -1,0 +1,43 @@
+//
+//  UserAPI.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/12/24.
+//
+
+import Foundation
+import Moya
+import RxSwift
+import RxMoya
+
+class UserAPI {
+    
+    static let provider = MoyaProvider<UserService>(plugins: [MoyaLoggerPlugin()])
+    var disposeBag = DisposeBag()
+    var userInfo = PublishSubject<UserResponse>()
+    
+    /// /user/profile .get 요청
+    static func getUserInfo() -> Observable<UserResponse> {
+        let decoder = JSONDecoder()
+        
+        return provider.rx.request(.getUserInfo)
+            .map(UserResponse.self, using: decoder)
+            .asObservable()
+            .catch { error in
+                if let moyaError = error as? MoyaError {
+                    switch moyaError {
+                        case .statusCode(let response):
+                            // HTTP 상태 코드에 따른 처리
+                            print("HTTP Status Code: \(response.statusCode)")
+                        case .jsonMapping(let response):
+                            // JSON 매핑 에러 처리
+                            print("JSON Mapping Error for Response: \(response)")
+                        default:
+                            // 기타 Moya 에러 처리
+                            print("Other MoyaError: \(moyaError.localizedDescription)")
+                    }
+                }
+                return Observable.error(error)
+            }
+    }
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
@@ -27,13 +27,10 @@ class UserAPI {
                 if let moyaError = error as? MoyaError {
                     switch moyaError {
                         case .statusCode(let response):
-                            // HTTP 상태 코드에 따른 처리
                             print("HTTP Status Code: \(response.statusCode)")
                         case .jsonMapping(let response):
-                            // JSON 매핑 에러 처리
                             print("JSON Mapping Error for Response: \(response)")
                         default:
-                            // 기타 Moya 에러 처리
                             print("Other MoyaError: \(moyaError.localizedDescription)")
                     }
                 }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
@@ -1,0 +1,47 @@
+//
+//  UserService.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/12/24.
+//
+
+import Foundation
+import Moya
+
+enum UserService {
+    case getUserInfo
+}
+
+extension UserService: TargetType {
+    var baseURL: URL {
+        return URL(string: Const.URL.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+            case .getUserInfo:
+                return "/user/profile"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+            case .getUserInfo:
+                return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+            case .getUserInfo:
+                return .requestPlain
+        }
+    }
+    
+    var headers: [String: String]? {
+        guard let accessToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) else {
+            return nil
+        }
+        return ["Content-Type": "application/json", "Authorization": "Bearer \(accessToken)"]
+    }
+}

--- a/Wetox-iOS/Wetox-iOS/Utility/Constants.swift
+++ b/Wetox-iOS/Wetox-iOS/Utility/Constants.swift
@@ -25,8 +25,8 @@ struct Constants {
     
     struct Time {
         /// 24시간 * 60분
-        static let maxMinutes = 1440
-        static let minMinutes = 0
+        static let maxMinutes: Int = 1440
+        static let minMinutes: Int = 0
     }
     
     struct ScreenTimeInput {
@@ -55,11 +55,30 @@ struct Constants {
     }
     
     struct Category {
+        /*
         static let categories = [
             "엔터테인먼트", "소셜미디어", "생산성 및 금융", "게임",
             "여행", "정보 및 도서", "유틸리티", "쇼핑 및 음식",
             "교육", "창의력", "건강 및 피트니스", "기타"
         ]
+         */
+        
+        static let categoriesKoreanToEnglish: [String: String] = [
+            "엔터테인먼트": "ENTERTAINEMENT",
+            "소셜미디어": "SOCIAL_MEDIA",
+            "생산성 및 금융": "PRODUCTIVITY_AND_FINANCE",
+            "게임": "GAME",
+            "여행": "TRAVEL",
+            "정보 및 도서": "INFORMATION_AND_BOOK",
+            "유틸리티": "UTILITY",
+            "쇼핑 및 음식": "SHOPPING_AND_FOOD",
+            "교육": "EDUCATION",
+            "창의력": "CREATIVITY",
+            "건강 및 피트니스": "HEALTH_AND_FEATNESS",
+            "기타": "OTHERS"
+        ]
+        
+        static let categories = Array(categoriesKoreanToEnglish.keys)
     }
     
     struct Slider {

--- a/Wetox-iOS/Wetox-iOS/View/MainViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/MainViewController.swift
@@ -60,22 +60,13 @@ class MainViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
         mainViewModel = MainViewModel()
-//        subscribeToUserInfo()
         [segmentedControl, friendsCollectionView, bottomSheetView].forEach { view.addSubview($0) }
-        
         bottomSheetView.addSubview(dragIndicatorView)
         configureLayout()
         configureUnselectedSegmentedControl()
         setupCollectionView()
         recognizeGesture()
-        
-        
         navigationController?.isNavigationBarHidden = true
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
     }
     
     private func configureLayout() {

--- a/Wetox-iOS/Wetox-iOS/View/ScreenTimeInputView/CustomUISlider.swift
+++ b/Wetox-iOS/Wetox-iOS/View/ScreenTimeInputView/CustomUISlider.swift
@@ -131,7 +131,7 @@ class CustomUISlider: UISlider {
     private func colorForValue(_ value: Float) -> UIColor {
         let maxValue = Float(Constants.Time.maxMinutes)
         let minValue = Float(Constants.Time.minMinutes)
-        let colorStep = Float(maxValue / 4)
+        let colorStep = maxValue / 4
         
         switch value {
             case minValue..<colorStep:

--- a/Wetox-iOS/Wetox-iOS/View/ScreenTimeInputView/ScreenTimeInputViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/ScreenTimeInputView/ScreenTimeInputViewController.swift
@@ -62,13 +62,18 @@ class ScreenTimeInputViewController: UIViewController {
         title = "스크린타임 입력하기"
         
         // TODO: 데이터 저장 및 메인에 적용 구현
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissViewController))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneButtonTapped))
         
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissViewController))
     }
     
     @objc private func dismissViewController() {
         dismiss(animated: true)
+    }
+    
+    @objc private func doneButtonTapped() {
+        screenTimeInputViewModel.postScreenTimeData()
+        dismissViewController()
     }
     
     private func configureLayout() {

--- a/Wetox-iOS/Wetox-iOS/ViewModel/MainViewModel.swift
+++ b/Wetox-iOS/Wetox-iOS/ViewModel/MainViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  MainViewModel.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/11/24.
+//
+
+import Foundation

--- a/Wetox-iOS/Wetox-iOS/ViewModel/MainViewModel.swift
+++ b/Wetox-iOS/Wetox-iOS/ViewModel/MainViewModel.swift
@@ -6,3 +6,19 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
+
+class MainViewModel {
+    
+    let disposeBag = DisposeBag()
+    
+    let myProfile: Observable<(nickname: String, imageName: String)>
+    
+    init(userAPI: UserAPI = .init()) {
+        myProfile = UserAPI.getUserInfo()
+            .map { ($0.nickname, $0.profileImage) }
+            .catch { _ in Observable.just(("unknown", "person")) }
+            .share(replay: 1, scope: .whileConnected)
+    }
+}

--- a/Wetox-iOS/Wetox-iOS/ViewModel/MainViewModel.swift
+++ b/Wetox-iOS/Wetox-iOS/ViewModel/MainViewModel.swift
@@ -14,11 +14,17 @@ class MainViewModel {
     let disposeBag = DisposeBag()
     
     let myProfile: Observable<(nickname: String, imageName: String)>
+    let percentage: Observable<Double>
     
     init(userAPI: UserAPI = .init()) {
         myProfile = UserAPI.getUserInfo()
             .map { ($0.nickname, $0.profileImage) }
             .catch { _ in Observable.just(("unknown", "person")) }
+            .share(replay: 1, scope: .whileConnected)
+        
+        percentage = ScreenTimeAPI.getScreenTime()
+            .map { Double($0.totalDuration) / Double(1440) }
+            .asObservable()
             .share(replay: 1, scope: .whileConnected)
     }
 }

--- a/Wetox-iOS/Wetox-iOS/ViewModel/ScreenTimeInputViewModel.swift
+++ b/Wetox-iOS/Wetox-iOS/ViewModel/ScreenTimeInputViewModel.swift
@@ -7,16 +7,19 @@
 
 import Foundation
 
+import Moya
 import RxSwift
 import RxCocoa
+import RxMoya
 
 class ScreenTimeInputViewModel {
     
     let totalSliderValue: Observable<Float>
+    var sliderValues: [Observable<Float>]
     var isExceededSubject = BehaviorSubject<Bool>(value: false)
+    let disposeBag = DisposeBag()
     
-    /** ScreenTimeInputView에서 선택하는 각 category 들의 총 합이 24시간을 넘지 않는지 체크
-     */
+    /// ScreenTimeInputView에서 선택하는 각 category 들의 총 합이 24시간을 넘지 않는지 체크
     var isExceeded: Observable<Bool> {
         return isExceededSubject.asObservable()
     }
@@ -30,5 +33,29 @@ class ScreenTimeInputViewModel {
         
         _ = totalSliderValue.map { $0 > 1440 }
             .bind(to: isExceededSubject)
+        
+        self.sliderValues = sliderValues
+    }
+    
+    /// 사용자가 입력하는 해당 category의 duration을 서버로 post 합니다
+    func postScreenTimeData() {
+        Observable.zip(sliderValues) { values in
+            return values.enumerated().map { index, value in
+                let koreanCategoryName = Constants.Category.categories[index]
+                let englishCategoryName = Constants.Category.categoriesKoreanToEnglish[koreanCategoryName] ?? "OTHERS"
+                return CategoryDurationRequest(category: englishCategoryName, duration: Int(value))
+            }
+        }
+        .flatMapLatest { categoryDurations in
+            ScreenTimeAPI.postCategoryDuration(data: categoryDurations)
+        }
+        .observe(on: MainScheduler.instance)
+        .subscribe(onNext: { response in
+            print("ScreenTimeInputViewModel에서 post 성공")
+            print("response: \(response.nickname), \(response.updatedDate), \(response.totalDuration), \(response.categoryScreenTimes)")
+        }, onError: { error in
+            print("viewmodel error: \(error.localizedDescription)")
+        })
+        .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
# Summary & Issues

<!-- 작업 내용 요약 및 이슈 번호 작성해주세요 -->

Closes #11 


### Contents 
<!-- 작업내용을 상세하게 작성해주세요 / Screen Capture가 있다면 첨부해주세요 -->

## ScreenTime, UserProfile API 구현 
- `postCategoryDuration(data: [CategoryDurationRequest])` 
    사용자가 입력한 Category와 duration을 서버로 post 합니다. 

- `getScreenTime()` 
    사용자 자신이 사용한 스크린타임의 Category, Duration을 받아옵니다. 

- `getUserScreenTime(userId: String)` 
    특정 유저의 닉네임을 파라미터로 받아 Category, Duration 등을 받아옵니다. 반환 타입은 `CategoryDurationResponse` 입니다. 

- `getUserInfo()` 
    유저의 정보를 서버에서 받아옵니다. 반환 탕비은 UserResponse 로 받아와 닉네임, 프로필 이미지 등을 업데이트하는데 사용합니다. 

### References
<!-- 참고한 자료가 있거나, 리뷰어에게 도움이 될 자료가 있다면 작성해주세요 -->


### Test 
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
- 실 기기 및 시뮬레이터 모두 테스트 가능합니다. 


### Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
