### PR TITLE
[FEAT] Friend Search API 연동 구현

### DIFF
--- a/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
+++ b/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
@@ -27,6 +27,13 @@
 		55A777652B66262C007FAEBF /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 55A777642B66262C007FAEBF /* Moya */; };
 		55A777672B66262C007FAEBF /* ReactiveMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 55A777662B66262C007FAEBF /* ReactiveMoya */; };
 		55A777692B66262C007FAEBF /* RxMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 55A777682B66262C007FAEBF /* RxMoya */; };
+		55EC6D812B7DE8530018128D /* FriendshipViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D802B7DE8530018128D /* FriendshipViewController.swift */; };
+		55EC6D852B7DFC7E0018128D /* FriendshipService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D842B7DFC7E0018128D /* FriendshipService.swift */; };
+		55EC6D872B7DFC8A0018128D /* FriendshipAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D862B7DFC8A0018128D /* FriendshipAPI.swift */; };
+		55EC6D892B7E07CB0018128D /* requestFriendshipResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D882B7E07CB0018128D /* requestFriendshipResponse.swift */; };
+		55EC6D8B2B7E07DA0018128D /* acceptFriendshipResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D8A2B7E07DA0018128D /* acceptFriendshipResponse.swift */; };
+		55EC6D8D2B7E07E50018128D /* getFriendsListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D8C2B7E07E50018128D /* getFriendsListResponse.swift */; };
+		55EC6D8F2B7E07F10018128D /* getFriendRequestsListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D8E2B7E07F10018128D /* getFriendRequestsListResponse.swift */; };
 		55F42F722B72347800ECDA2E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 55F42F712B72347800ECDA2E /* GoogleService-Info.plist */; };
 		55F42F752B7235B800ECDA2E /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 55F42F742B7235B800ECDA2E /* FirebaseMessaging */; };
 		BF0EBDDF2B6529D000AEF19D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7209BA2B5F8BCB001D76CB /* AppDelegate.swift */; };
@@ -97,6 +104,13 @@
 		558601972B6629A6007EA357 /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
 		55A097A62B7CC6B400F1D43E /* NetworkErrorUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorUtils.swift; sourceTree = "<group>"; };
 		55EA5F432B72368F00788E0A /* Wetox-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Wetox-iOS.entitlements"; sourceTree = "<group>"; };
+		55EC6D802B7DE8530018128D /* FriendshipViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendshipViewController.swift; sourceTree = "<group>"; };
+		55EC6D842B7DFC7E0018128D /* FriendshipService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendshipService.swift; sourceTree = "<group>"; };
+		55EC6D862B7DFC8A0018128D /* FriendshipAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendshipAPI.swift; sourceTree = "<group>"; };
+		55EC6D882B7E07CB0018128D /* requestFriendshipResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = requestFriendshipResponse.swift; sourceTree = "<group>"; };
+		55EC6D8A2B7E07DA0018128D /* acceptFriendshipResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = acceptFriendshipResponse.swift; sourceTree = "<group>"; };
+		55EC6D8C2B7E07E50018128D /* getFriendsListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = getFriendsListResponse.swift; sourceTree = "<group>"; };
+		55EC6D8E2B7E07F10018128D /* getFriendRequestsListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = getFriendRequestsListResponse.swift; sourceTree = "<group>"; };
 		55F42F712B72347800ECDA2E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BF2FE0232B64C742009C3C73 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		BF2FE0252B64CBC9009C3C73 /* ScreenTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTime.swift; sourceTree = "<group>"; };
@@ -175,6 +189,7 @@
 			isa = PBXGroup;
 			children = (
 				55A097A62B7CC6B400F1D43E /* NetworkErrorUtils.swift */,
+				55EC6D822B7DE8860018128D /* Friendship */,
 				BF7181DB2B7A2EA500ACEA0D /* User */,
 				BF7181D22B749EA800ACEA0D /* ScreenTime */,
 				5514CE622B65F87F006B2700 /* Plugin */,
@@ -186,8 +201,8 @@
 		5514CE5C2B65F704006B2700 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
-				5514CE5D2B65F719006B2700 /* AuthAPI.swift */,
 				5514CE5F2B65F721006B2700 /* AuthService.swift */,
+				5514CE5D2B65F719006B2700 /* AuthAPI.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -203,6 +218,7 @@
 		554F273E2B638ECF0050B6D9 /* NetworkModel */ = {
 			isa = PBXGroup;
 			children = (
+				55EC6D832B7DE88E0018128D /* Friendship */,
 				BF7181E02B7A2F6E00ACEA0D /* User */,
 				BF7181CF2B73588800ACEA0D /* ScreenTime */,
 				554F27442B6390BE0050B6D9 /* Auth */,
@@ -236,6 +252,26 @@
 				554F27482B6391E20050B6D9 /* RegisterResponse.swift */,
 			);
 			path = Register;
+			sourceTree = "<group>";
+		};
+		55EC6D822B7DE8860018128D /* Friendship */ = {
+			isa = PBXGroup;
+			children = (
+				55EC6D842B7DFC7E0018128D /* FriendshipService.swift */,
+				55EC6D862B7DFC8A0018128D /* FriendshipAPI.swift */,
+			);
+			path = Friendship;
+			sourceTree = "<group>";
+		};
+		55EC6D832B7DE88E0018128D /* Friendship */ = {
+			isa = PBXGroup;
+			children = (
+				55EC6D882B7E07CB0018128D /* requestFriendshipResponse.swift */,
+				55EC6D8A2B7E07DA0018128D /* acceptFriendshipResponse.swift */,
+				55EC6D8C2B7E07E50018128D /* getFriendsListResponse.swift */,
+				55EC6D8E2B7E07F10018128D /* getFriendRequestsListResponse.swift */,
+			);
+			path = Friendship;
 			sourceTree = "<group>";
 		};
 		BF2FE0222B64C731009C3C73 /* Utility */ = {
@@ -368,6 +404,7 @@
 			children = (
 				BF6B12DA2B64B8FF0031165E /* ScreenTimeInputView */,
 				5544128F2B608CA9001B8CBA /* LoginViewController.swift */,
+				55EC6D802B7DE8530018128D /* FriendshipViewController.swift */,
 				552FE1732B6118DE00A4F568 /* ProfileSettingViewContorller.swift */,
 				BF7209BE2B5F8BCB001D76CB /* MainViewController.swift */,
 				BF7209F42B5F923F001D76CB /* FriendsCollectionViewCell.swift */,
@@ -550,31 +587,38 @@
 				5514CE5E2B65F719006B2700 /* AuthAPI.swift in Sources */,
 				554F27472B6391D80050B6D9 /* RegisterRequest.swift in Sources */,
 				BF7209F52B5F923F001D76CB /* FriendsCollectionViewCell.swift in Sources */,
+				55EC6D872B7DFC8A0018128D /* FriendshipAPI.swift in Sources */,
 				554F27432B63908E0050B6D9 /* TokenResponse.swift in Sources */,
 				BF7209F02B5F8CCB001D76CB /* Color+Extension.swift in Sources */,
 				BFB317AC2B6693A4007F0A9A /* View+Extension.swift in Sources */,
 				552FE1742B6118DE00A4F568 /* ProfileSettingViewContorller.swift in Sources */,
 				556AA2D02B6A3B2B00F2AE79 /* TextField+Extension.swift in Sources */,
+				55EC6D892B7E07CB0018128D /* requestFriendshipResponse.swift in Sources */,
 				BF7181D12B7358CA00ACEA0D /* CategoryDurationRequest.swift in Sources */,
 				BF7181D82B74A13100ACEA0D /* ScreenTimeAPI.swift in Sources */,
 				BF7181E42B7A2F8900ACEA0D /* UserResponse.swift in Sources */,
+				55EC6D8B2B7E07DA0018128D /* acceptFriendshipResponse.swift in Sources */,
 				BF0EBDDF2B6529D000AEF19D /* AppDelegate.swift in Sources */,
 				BF7181E62B7B56D600ACEA0D /* DateFormatter+Extension.swift in Sources */,
 				BF7181D62B74A0F800ACEA0D /* CategoryDurationResponse.swift in Sources */,
 				BFB317A82B666962007F0A9A /* ScreenTimeInputViewModel.swift in Sources */,
 				BFB317A52B6666AF007F0A9A /* TimeConverter.swift in Sources */,
 				55A097A72B7CC6B400F1D43E /* NetworkErrorUtils.swift in Sources */,
+				55EC6D8D2B7E07E50018128D /* getFriendsListResponse.swift in Sources */,
 				BFB317A32B665744007F0A9A /* StrokeLabel.swift in Sources */,
 				BF7181DF2B7A2EBB00ACEA0D /* UserAPI.swift in Sources */,
 				BF7209BF2B5F8BCB001D76CB /* MainViewController.swift in Sources */,
 				558601982B6629A6007EA357 /* Const.swift in Sources */,
+				55EC6D8F2B7E07F10018128D /* getFriendRequestsListResponse.swift in Sources */,
 				554412902B608CA9001B8CBA /* LoginViewController.swift in Sources */,
+				55EC6D852B7DFC7E0018128D /* FriendshipService.swift in Sources */,
 				5514CE642B65F891006B2700 /* MoyaLoggerPlugin.swift in Sources */,
 				BF7181DD2B7A2EB300ACEA0D /* UserService.swift in Sources */,
 				BF7209F72B5F926B001D76CB /* CircularProgressBar.swift in Sources */,
 				BFB317AA2B669358007F0A9A /* BottomSheetView.swift in Sources */,
 				BF7209BD2B5F8BCB001D76CB /* SceneDelegate.swift in Sources */,
 				554F27492B6391E20050B6D9 /* RegisterResponse.swift in Sources */,
+				55EC6D812B7DE8530018128D /* FriendshipViewController.swift in Sources */,
 				BF7181DA2B78E4DD00ACEA0D /* MainViewModel.swift in Sources */,
 				BF7181D42B749EC400ACEA0D /* ScreenTimeService.swift in Sources */,
 				557F3EA22B60983A007C7247 /* Button+Extension.swift in Sources */,

--- a/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
+++ b/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		55A777652B66262C007FAEBF /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 55A777642B66262C007FAEBF /* Moya */; };
 		55A777672B66262C007FAEBF /* ReactiveMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 55A777662B66262C007FAEBF /* ReactiveMoya */; };
 		55A777692B66262C007FAEBF /* RxMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 55A777682B66262C007FAEBF /* RxMoya */; };
+		55BD1F2B2B8203A6009601AC /* NicknameSearchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BD1F2A2B8203A6009601AC /* NicknameSearchRequest.swift */; };
+		55BD1F2D2B8203CB009601AC /* NicknameSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BD1F2C2B8203CB009601AC /* NicknameSearchResponse.swift */; };
 		55EC6D812B7DE8530018128D /* FriendshipViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D802B7DE8530018128D /* FriendshipViewController.swift */; };
 		55EC6D852B7DFC7E0018128D /* FriendshipService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D842B7DFC7E0018128D /* FriendshipService.swift */; };
 		55EC6D872B7DFC8A0018128D /* FriendshipAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D862B7DFC8A0018128D /* FriendshipAPI.swift */; };
@@ -104,6 +106,8 @@
 		557F3EA12B60983A007C7247 /* Button+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Button+Extension.swift"; sourceTree = "<group>"; };
 		558601972B6629A6007EA357 /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
 		55A097A62B7CC6B400F1D43E /* NetworkErrorUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorUtils.swift; sourceTree = "<group>"; };
+		55BD1F2A2B8203A6009601AC /* NicknameSearchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSearchRequest.swift; sourceTree = "<group>"; };
+		55BD1F2C2B8203CB009601AC /* NicknameSearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSearchResponse.swift; sourceTree = "<group>"; };
 		55EA5F432B72368F00788E0A /* Wetox-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Wetox-iOS.entitlements"; sourceTree = "<group>"; };
 		55EC6D802B7DE8530018128D /* FriendshipViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendshipViewController.swift; sourceTree = "<group>"; };
 		55EC6D842B7DFC7E0018128D /* FriendshipService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendshipService.swift; sourceTree = "<group>"; };
@@ -326,6 +330,8 @@
 			isa = PBXGroup;
 			children = (
 				BF7181E32B7A2F8900ACEA0D /* UserResponse.swift */,
+				55BD1F2A2B8203A6009601AC /* NicknameSearchRequest.swift */,
+				55BD1F2C2B8203CB009601AC /* NicknameSearchResponse.swift */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -595,6 +601,7 @@
 				BF7209F02B5F8CCB001D76CB /* Color+Extension.swift in Sources */,
 				BFB317AC2B6693A4007F0A9A /* View+Extension.swift in Sources */,
 				552FE1742B6118DE00A4F568 /* ProfileSettingViewContorller.swift in Sources */,
+				55BD1F2B2B8203A6009601AC /* NicknameSearchRequest.swift in Sources */,
 				556AA2D02B6A3B2B00F2AE79 /* TextField+Extension.swift in Sources */,
 				55EC6D892B7E07CB0018128D /* requestFriendshipResponse.swift in Sources */,
 				55EC6D912B7E10A70018128D /* AlertViewController.swift in Sources */,
@@ -603,6 +610,7 @@
 				BF7181E42B7A2F8900ACEA0D /* UserResponse.swift in Sources */,
 				55EC6D8B2B7E07DA0018128D /* acceptFriendshipResponse.swift in Sources */,
 				BF0EBDDF2B6529D000AEF19D /* AppDelegate.swift in Sources */,
+				55BD1F2D2B8203CB009601AC /* NicknameSearchResponse.swift in Sources */,
 				BF7181E62B7B56D600ACEA0D /* DateFormatter+Extension.swift in Sources */,
 				BF7181D62B74A0F800ACEA0D /* CategoryDurationResponse.swift in Sources */,
 				BFB317A82B666962007F0A9A /* ScreenTimeInputViewModel.swift in Sources */,

--- a/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
+++ b/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		55EC6D8B2B7E07DA0018128D /* acceptFriendshipResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D8A2B7E07DA0018128D /* acceptFriendshipResponse.swift */; };
 		55EC6D8D2B7E07E50018128D /* getFriendsListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D8C2B7E07E50018128D /* getFriendsListResponse.swift */; };
 		55EC6D8F2B7E07F10018128D /* getFriendRequestsListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D8E2B7E07F10018128D /* getFriendRequestsListResponse.swift */; };
+		55EC6D912B7E10A70018128D /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EC6D902B7E10A70018128D /* AlertViewController.swift */; };
 		55F42F722B72347800ECDA2E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 55F42F712B72347800ECDA2E /* GoogleService-Info.plist */; };
 		55F42F752B7235B800ECDA2E /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 55F42F742B7235B800ECDA2E /* FirebaseMessaging */; };
 		BF0EBDDF2B6529D000AEF19D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7209BA2B5F8BCB001D76CB /* AppDelegate.swift */; };
@@ -111,6 +112,7 @@
 		55EC6D8A2B7E07DA0018128D /* acceptFriendshipResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = acceptFriendshipResponse.swift; sourceTree = "<group>"; };
 		55EC6D8C2B7E07E50018128D /* getFriendsListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = getFriendsListResponse.swift; sourceTree = "<group>"; };
 		55EC6D8E2B7E07F10018128D /* getFriendRequestsListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = getFriendRequestsListResponse.swift; sourceTree = "<group>"; };
+		55EC6D902B7E10A70018128D /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		55F42F712B72347800ECDA2E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BF2FE0232B64C742009C3C73 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		BF2FE0252B64CBC9009C3C73 /* ScreenTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTime.swift; sourceTree = "<group>"; };
@@ -404,6 +406,7 @@
 			children = (
 				BF6B12DA2B64B8FF0031165E /* ScreenTimeInputView */,
 				5544128F2B608CA9001B8CBA /* LoginViewController.swift */,
+				55EC6D902B7E10A70018128D /* AlertViewController.swift */,
 				55EC6D802B7DE8530018128D /* FriendshipViewController.swift */,
 				552FE1732B6118DE00A4F568 /* ProfileSettingViewContorller.swift */,
 				BF7209BE2B5F8BCB001D76CB /* MainViewController.swift */,
@@ -594,6 +597,7 @@
 				552FE1742B6118DE00A4F568 /* ProfileSettingViewContorller.swift in Sources */,
 				556AA2D02B6A3B2B00F2AE79 /* TextField+Extension.swift in Sources */,
 				55EC6D892B7E07CB0018128D /* requestFriendshipResponse.swift in Sources */,
+				55EC6D912B7E10A70018128D /* AlertViewController.swift in Sources */,
 				BF7181D12B7358CA00ACEA0D /* CategoryDurationRequest.swift in Sources */,
 				BF7181D82B74A13100ACEA0D /* ScreenTimeAPI.swift in Sources */,
 				BF7181E42B7A2F8900ACEA0D /* UserResponse.swift in Sources */,

--- a/Wetox-iOS/Wetox-iOS/Extension/Color+Extension.swift
+++ b/Wetox-iOS/Wetox-iOS/Extension/Color+Extension.swift
@@ -72,6 +72,10 @@ extension UIColor {
         return UIColor(hexCode: "30DB5B")
     }
     
+    static var checkRedButtonColor: UIColor {
+        return UIColor(hexCode: "FF6961")
+    }
+    
     static var textDeleteButtonColor: UIColor {
         return UIColor(hexCode: "8E8E93")
     }

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/acceptFriendshipResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/acceptFriendshipResponse.swift
@@ -16,7 +16,6 @@ struct acceptFriendshipResponse: Codable {
     let status: String
 }
 
-// TODO: Q
 enum status: String {
     case accept = "ACCEPT"
 }

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/acceptFriendshipResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/acceptFriendshipResponse.swift
@@ -1,0 +1,22 @@
+//
+//  acceptFriendshipResponse.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/15/24.
+//
+
+import Foundation
+
+struct acceptFriendshipResponse: Codable {
+    let friendshipId: Int64
+    let from: Int64
+    let to: Int64
+    let createDate: Date
+    let requestDate: Date
+    let status: String
+}
+
+// TODO: Q
+enum status: String {
+    case accept = "ACCEPT"
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/getFriendRequestsListResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/getFriendRequestsListResponse.swift
@@ -1,0 +1,18 @@
+//
+//  getFriendRequestsListResponse.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/15/24.
+//
+
+import Foundation
+
+struct getFriendRequestsListResponse: Codable {
+    let FriendRequestsList: [FriendRequest]
+}
+
+struct FriendRequest: Codable {
+    let friendshipId: Int64
+    let fromUserId: Int64
+    let requestedData: Date
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/getFriendsListResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/getFriendsListResponse.swift
@@ -1,0 +1,18 @@
+//
+//  getFriendsListResponse.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/15/24.
+//
+
+import Foundation
+
+struct getFriendsListResponse: Codable {
+    let FriendsList: [Friend]
+}
+
+struct Friend: Codable {
+    let userId: Int64
+    let nickname: String
+    let totalDuration: Int64
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/requestFriendshipResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Friendship/requestFriendshipResponse.swift
@@ -1,0 +1,15 @@
+//
+//  requestFriendshipResponse.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/15/24.
+//
+
+import Foundation
+
+struct requestFriendshipResponse: Codable {
+    let friendshipId: Int64
+    let fromUserId: Int64
+    let fromUserNickname: String
+    let requestedDate: Date
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/User/NicknameSearchRequest.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/User/NicknameSearchRequest.swift
@@ -1,0 +1,12 @@
+//
+//  NicknameSearchRequest.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/18/24.
+//
+
+import Foundation
+
+struct NicknameSearchRequest: Codable {
+    let nickname: String
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/User/NicknameSearchResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/User/NicknameSearchResponse.swift
@@ -1,0 +1,14 @@
+//
+//  NicknameSearchResponse.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/18/24.
+//
+
+import Foundation
+
+struct NicknameSearchResponse: Codable {
+    let userId: Int64
+    let nickname: String
+    let profileImage: String
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkService/Friendship/FriendshipAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/Friendship/FriendshipAPI.swift
@@ -12,41 +12,5 @@ import RxMoya
 
 public class FriendshipAPI {
     static let friendshipProvider = MoyaProvider<FriendshipService>(plugins: [MoyaLoggerPlugin()])
-    
-    static func register(registerRequest: RegisterRequest, profileImage: UIImage?) -> Observable<RegisterResponse> {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        
-        return AuthAPI.authProvider.rx.request(.register(registerRequest: registerRequest, profileImage: profileImage))
-            .map(RegisterResponse.self, using: decoder)
-            .asObservable()
-            .catch { error in
-                if let moyaError = error as? MoyaError {
-                    switch moyaError {
-                    case .statusCode(let response):
-                        // HTTP 상태 코드에 따른 처리
-                        print("HTTP Status Code: \(response.statusCode)")
-                    case .jsonMapping(let response):
-                        // JSON 매핑 에러 처리
-                        print("JSON Mapping Error for Response: \(response)")
-                    default:
-                        // 기타 Moya 에러 처리
-                        print("Other MoyaError: \(moyaError.localizedDescription)")
-                    }
-                }
-                return Observable.error(error)
-            }
-    }
-    
-    static func login(tokenRequest: TokenRequest) -> Observable<TokenResponse> {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        
-        return AuthAPI.authProvider.rx.request(.login(tokenRequest: tokenRequest))
-            .map(TokenResponse.self, using: decoder)
-            .asObservable()
-            .catch { error in
-                NetworkErrorUtils.shared.handleTokenError(error: error, request: .login(tokenRequest: tokenRequest))
-            }
-    }
+
 }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/Friendship/FriendshipAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/Friendship/FriendshipAPI.swift
@@ -1,8 +1,8 @@
 //
-//  AuthAPI.swift
+//  FriendshipAPI.swift
 //  Wetox-iOS
 //
-//  Created by 김소현 on 1/28/24.
+//  Created by 김소현 on 2/15/24.
 //
 
 import UIKit
@@ -10,8 +10,8 @@ import Moya
 import RxSwift
 import RxMoya
 
-public class AuthAPI {
-    static let authProvider = MoyaProvider<AuthService>(plugins: [MoyaLoggerPlugin()])
+public class FriendshipAPI {
+    static let friendshipProvider = MoyaProvider<FriendshipService>(plugins: [MoyaLoggerPlugin()])
     
     static func register(registerRequest: RegisterRequest, profileImage: UIImage?) -> Observable<RegisterResponse> {
         let decoder = JSONDecoder()

--- a/Wetox-iOS/Wetox-iOS/NetworkService/Friendship/FriendshipService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/Friendship/FriendshipService.swift
@@ -35,7 +35,9 @@ extension FriendshipService: TargetType {
     
     var method: Moya.Method {
         switch self {
-        case .requestFriendship, .acceptFriendship, .getFriendsList, .getFriendRequestsList:
+        case .requestFriendship, .acceptFriendship:
+            return .post
+        case .getFriendsList, .getFriendRequestsList:
             return .get
         }
     }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/Friendship/FriendshipService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/Friendship/FriendshipService.swift
@@ -1,0 +1,56 @@
+//
+//  FriendshipService.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/15/24.
+//
+
+import Foundation
+import Moya
+
+enum FriendshipService {
+    case requestFriendship(toId: String)
+    case acceptFriendship(toId: String)
+    case getFriendsList
+    case getFriendRequestsList
+}
+
+extension FriendshipService: TargetType {
+    var baseURL: URL {
+        return URL(string: Const.URL.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .requestFriendship(let toId):
+            return "/friendship/request/\(toId)"
+        case .acceptFriendship(let toId):
+            return "/friendship/accept/\(toId)"
+        case .getFriendsList:
+            return "/frienship"
+        case .getFriendRequestsList:
+            return "/friendship/request"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .requestFriendship, .acceptFriendship, .getFriendsList, .getFriendRequestsList:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .requestFriendship, .acceptFriendship, .getFriendsList, .getFriendRequestsList:
+                return .requestPlain
+        }
+    }
+    
+    var headers: [String: String]? {
+        guard let accessToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) else {
+            return nil
+        }
+        return ["Content-Type": "application/json", "Authorization": "Bearer \(accessToken)"]
+    }
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
@@ -38,5 +38,25 @@ class UserAPI {
             }
     }
     
-    // TODO: 친구 목록 받아오기 API 구현 
+    static func nicknameSearch(data: NicknameSearchRequest) -> Observable<NicknameSearchResponse> {
+        
+        let decoder = JSONDecoder()
+
+        return provider.rx.request(.nicknameSearch(data: data))
+            .map(NicknameSearchResponse.self, using: decoder)
+            .asObservable()
+            .catch { error in
+                if let moyaError = error as? MoyaError {
+                    switch moyaError {
+                    case .statusCode(let response):
+                        print("HTTP Status Code: \(response.statusCode)")
+                    case .jsonMapping(let response):
+                        print("JSON Mapping Error for Response: \(response)")
+                    default:
+                        print("Other MoyaError: \(moyaError.localizedDescription)")
+                    }
+                }
+                return Observable.error(error)
+            }
+    }
 }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
@@ -68,5 +68,11 @@ class UserAPI {
                 }
                 return Observable.error(error)
             }
+        
+        // TODO: NetworkErrorUtils 호출 시, Observable<NicknameSearchResponse> 반환 형태 불일치
+        
+        /*
+         NetworkErrorUtils.shared.handleTokenError(error: error, request: .login(tokenRequest: TokenRequest(oauthProvider: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.oauthProvider) ?? String(), openId: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.openId) ?? String())))
+         */
     }
 }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
@@ -37,4 +37,6 @@ class UserAPI {
                 return Observable.error(error)
             }
     }
+    
+    // TODO: 친구 목록 받아오기 API 구현 
 }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserAPI.swift
@@ -41,10 +41,20 @@ class UserAPI {
     static func nicknameSearch(data: NicknameSearchRequest) -> Observable<NicknameSearchResponse> {
         
         let decoder = JSONDecoder()
-
+        decoder.dateDecodingStrategy = .formatted(DateFormatter().mapDateFormat())
+        
         return provider.rx.request(.nicknameSearch(data: data))
             .map(NicknameSearchResponse.self, using: decoder)
             .asObservable()
+            .do(onNext: { response in
+                // 서버 응답 데이터 출력
+                print("Server response data: \(response)")
+            }, onError: { error in
+                // 에러 발생 시 서버 응답 데이터 출력
+                if let response = (error as? MoyaError)?.response {
+                    print("Server error response data: \(response)")
+                }
+            })
             .catch { error in
                 if let moyaError = error as? MoyaError {
                     switch moyaError {

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
@@ -10,7 +10,7 @@ import Moya
 
 enum UserService {
     case getUserInfo
-    case nicknameSearch
+    case nicknameSearch(nickname: NicknameSearchRequest)
 }
 
 extension UserService: TargetType {
@@ -38,9 +38,8 @@ extension UserService: TargetType {
         switch self {
             case .getUserInfo:
                 return .requestPlain
-            case .nicknameSearch:
-                // TODO: 수정 need
-                return .requestPlain
+            case .nicknameSearch(let data):
+                return .requestJSONEncodable(data)
         }
     }
     

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
@@ -29,10 +29,8 @@ extension UserService: TargetType {
     
     var method: Moya.Method {
         switch self {
-            case .getUserInfo:
+            case .getUserInfo, .nicknameSearch:
                 return .get
-            case .nicknameSearch:
-                return .get // post?
         }
     }
     
@@ -41,8 +39,8 @@ extension UserService: TargetType {
             case .getUserInfo:
                 return .requestPlain
             case .nicknameSearch:
+                // TODO: 수정 need
                 return .requestPlain
-            // TODO: nicknameSearch Task 수정
         }
     }
     

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum UserService {
     case getUserInfo
+    case nicknameSearch
 }
 
 extension UserService: TargetType {
@@ -21,6 +22,8 @@ extension UserService: TargetType {
         switch self {
             case .getUserInfo:
                 return "/user/profile"
+            case .nicknameSearch:
+                return "user/search"
         }
     }
     
@@ -28,6 +31,8 @@ extension UserService: TargetType {
         switch self {
             case .getUserInfo:
                 return .get
+            case .nicknameSearch:
+                return .get // post?
         }
     }
     
@@ -35,6 +40,9 @@ extension UserService: TargetType {
         switch self {
             case .getUserInfo:
                 return .requestPlain
+            case .nicknameSearch:
+                return .requestPlain
+            // TODO: nicknameSearch Task 수정
         }
     }
     

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
@@ -29,8 +29,10 @@ extension UserService: TargetType {
     
     var method: Moya.Method {
         switch self {
-            case .getUserInfo, .nicknameSearch:
+            case .getUserInfo:
                 return .get
+            case .nicknameSearch:
+                return .post
         }
     }
     

--- a/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/User/UserService.swift
@@ -10,7 +10,7 @@ import Moya
 
 enum UserService {
     case getUserInfo
-    case nicknameSearch(nickname: NicknameSearchRequest)
+    case nicknameSearch(data: NicknameSearchRequest)
 }
 
 extension UserService: TargetType {

--- a/Wetox-iOS/Wetox-iOS/SceneDelegate.swift
+++ b/Wetox-iOS/Wetox-iOS/SceneDelegate.swift
@@ -27,7 +27,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
+        let accessToken = UserDefaults.standard.object(forKey: Const.UserDefaultsKey.accessToken)
+        print(accessToken!)
+        print("accessToken")
+        
+        if (accessToken as? String != String()) {
+            window?.rootViewController = UINavigationController(rootViewController: MainViewController())
+        } else {
+            window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
+        }
         window?.makeKeyAndVisible()
     }
 

--- a/Wetox-iOS/Wetox-iOS/View/AlertTableViewCell.swift
+++ b/Wetox-iOS/Wetox-iOS/View/AlertTableViewCell.swift
@@ -1,0 +1,8 @@
+//
+//  AlertTableViewCell.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/18/24.
+//
+
+import Foundation

--- a/Wetox-iOS/Wetox-iOS/View/AlertViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/AlertViewController.swift
@@ -1,0 +1,18 @@
+//
+//  AlertViewController.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/15/24.
+//
+
+import UIKit
+import SnapKit
+
+class AlertViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    
+}

--- a/Wetox-iOS/Wetox-iOS/View/AlertViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/AlertViewController.swift
@@ -7,8 +7,10 @@
 
 import UIKit
 import SnapKit
+import RxSwift
 
 class AlertViewController: UIViewController {
+    let disposeBag = DisposeBag()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
@@ -34,13 +34,13 @@ class FriendshipViewController: UIViewController {
         configureLayout()
         
         searchTextField.becomeFirstResponder()
-        searchTextField.rx.text
-                   .map { $0 ?? "" } 
-                   .map { $0.isEmpty }
-                   .subscribe(onNext: { [weak self] isEmpty in
-                       self?.checkingLabel.textColor = isEmpty ? .clear : UIColor.allowedButtonColor
-                   })
-                   .disposed(by: disposeBag)
+//        searchTextField.rx.text
+//                   .map { $0 ?? "" } 
+//                   .map { $0.isEmpty }
+//                   .subscribe(onNext: { [weak self] isEmpty in
+//                       self?.checkingLabel.textColor = isEmpty ? .clear : UIColor.allowedButtonColor
+//                   })
+//                   .disposed(by: disposeBag)
     }
     
     override func viewDidLayoutSubviews() {
@@ -95,6 +95,10 @@ class FriendshipViewController: UIViewController {
     
     @objc func friendSearchButtonTapped() {
         // TODO: API 호출 need
+        
+        let alertController = UIAlertController(title: "친구 추가 성공", message: "친구 신청이 완료되었습니다.", preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+        present(alertController, animated: true, completion: nil)
     }
     
     private func configureLayout() {
@@ -127,4 +131,27 @@ class FriendshipViewController: UIViewController {
             make.leading.equalToSuperview().inset(19)
         }
     }
+}
+
+extension FriendshipViewController {
+    func searchFriendAPI(nicknameText: String) {
+        // UserAPI에 추가되어야 하는 함수
+        
+    }
+    
+    /*
+    func registerWithAPI(registerRequest: RegisterRequest, profileImage: UIImage?) {
+        AuthAPI.register(registerRequest: registerRequest, profileImage: profileImage)
+            .subscribe(onNext: { registerResponse in
+                UserDefaults.standard.set(registerResponse.accessToken, forKey: Const.UserDefaultsKey.accessToken)
+                print("accessToken 값 입니다. ")
+                print(registerResponse.accessToken) // 확인
+                self.navigationController?.pushViewController(MainViewController(), animated: true)
+                print("회원가입 성공: \(registerResponse)")
+            }, onError: { error in
+                print("회원가입 실패: \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+    }
+     */
 }

--- a/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
@@ -34,13 +34,6 @@ class FriendshipViewController: UIViewController {
         configureLayout()
         
         searchTextField.becomeFirstResponder()
-//        searchTextField.rx.text
-//                   .map { $0 ?? "" } 
-//                   .map { $0.isEmpty }
-//                   .subscribe(onNext: { [weak self] isEmpty in
-//                       self?.checkingLabel.textColor = isEmpty ? .clear : UIColor.allowedButtonColor
-//                   })
-//                   .disposed(by: disposeBag)
     }
     
     override func viewDidLayoutSubviews() {
@@ -59,7 +52,7 @@ class FriendshipViewController: UIViewController {
                                backgroundColor: .clear,
                                weight: .light,
                                textSize: 12,
-                               labelColor: UIColor.allowedButtonColor)
+                               labelColor: UIColor.clear)
     }
     
     private func setupTextFieldLayout() {
@@ -94,11 +87,7 @@ class FriendshipViewController: UIViewController {
     }
     
     @objc func friendSearchButtonTapped() {
-        // TODO: API 호출 need
-        
-        let alertController = UIAlertController(title: "친구 추가 성공", message: "친구 신청이 완료되었습니다.", preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
-        present(alertController, animated: true, completion: nil)
+        self.searchFriendWithAPI(nicknameSearchRequest: NicknameSearchRequest(nickname: self.searchTextField.text ?? String()))
     }
     
     private func configureLayout() {
@@ -134,24 +123,22 @@ class FriendshipViewController: UIViewController {
 }
 
 extension FriendshipViewController {
-    func searchFriendAPI(nicknameText: String) {
-        // UserAPI에 추가되어야 하는 함수
-        
-    }
-    
-    /*
-    func registerWithAPI(registerRequest: RegisterRequest, profileImage: UIImage?) {
-        AuthAPI.register(registerRequest: registerRequest, profileImage: profileImage)
-            .subscribe(onNext: { registerResponse in
-                UserDefaults.standard.set(registerResponse.accessToken, forKey: Const.UserDefaultsKey.accessToken)
-                print("accessToken 값 입니다. ")
-                print(registerResponse.accessToken) // 확인
-                self.navigationController?.pushViewController(MainViewController(), animated: true)
-                print("회원가입 성공: \(registerResponse)")
+    func searchFriendWithAPI(nicknameSearchRequest: NicknameSearchRequest) {
+        UserAPI.nicknameSearch(data: nicknameSearchRequest)
+            .subscribe(onNext: { nicknameResponse in
+                print("nicknameResponse 값 입니다. ")
+                print("친구 찾기 성공: \(nicknameResponse)")
+                self.checkingLabel.textColor = UIColor.allowedButtonColor
+                
+                let alertController = UIAlertController(title: "친구 추가 성공", message: "친구 신청이 완료되었습니다.", preferredStyle: .alert)
+                alertController.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+                self.present(alertController, animated: true, completion: nil)
+                
             }, onError: { error in
-                print("회원가입 실패: \(error.localizedDescription)")
+                print("친구 찾기 실패: \(error.localizedDescription)")
+                self.checkingLabel.text = "존재하지 않는 사용자입니다."
+                self.checkingLabel.textColor = UIColor.checkRedButtonColor
             })
             .disposed(by: disposeBag)
     }
-     */
 }

--- a/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
@@ -10,9 +10,52 @@ import SnapKit
 
 class FriendshipViewController: UIViewController {
     
+    private var navigationButton: UIButton = UIButton()
+
+    private let nicknameLabel: UILabel = UILabel()
+    private let searchTextField = UITextField()
+    private var textDeleteButton: UIButton = UIButton()
+    private let checkingLabel: UILabel = UILabel()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.view.backgroundColor = .white
+        self.navigationItem.title = "친구 추가"
+        
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: navigationButton)
+        
+        [navigationButton, nicknameLabel, searchTextField, textDeleteButton, checkingLabel].forEach { view.addSubview($0) }
+        
+        setupLabelLayout()
+        setupTextFieldLayout()
+        setupButtonLayout()
+        configureLayout()
+        
+        searchTextField.becomeFirstResponder()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        searchTextField.setUnderLine(lineColor: UIColor.blockedButtonColor)
+    }
+    
+    private func setupLabelLayout() {
+        nicknameLabel.setLabel(labelText: "닉네임",
+                               backgroundColor: .clear,
+                               weight: .bold,
+                               textSize: 17,
+                               labelColor: .black)
+        
+        checkingLabel.setLabel(labelText: "존재하는 사용자입니다.",
+                               backgroundColor: .clear,
+                               weight: .light,
+                               textSize: 12,
+                               labelColor: UIColor.allowedButtonColor)
+    }
+    
+    private func setupTextFieldLayout() {
         
     }
+    
     
 }

--- a/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
@@ -57,5 +57,14 @@ class FriendshipViewController: UIViewController {
         
     }
     
+    private func setupButtonLayout() {
+        
+    }
     
+    private func configureLayout() {
+        nicknameLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(81)
+            make.leading.equalToSuperview().inset(20)
+        }
+    }
 }

--- a/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
@@ -1,0 +1,18 @@
+//
+//  FriendshipViewController.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/15/24.
+//
+
+import UIKit
+import SnapKit
+
+class FriendshipViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+    }
+    
+}

--- a/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/FriendshipViewController.swift
@@ -7,24 +7,26 @@
 
 import UIKit
 import SnapKit
+import RxSwift
 
 class FriendshipViewController: UIViewController {
+    let disposeBag = DisposeBag()
     
     private var navigationButton: UIButton = UIButton()
-
     private let nicknameLabel: UILabel = UILabel()
     private let searchTextField = UITextField()
     private var textDeleteButton: UIButton = UIButton()
+    private var friendSearchButton: UIButton = UIButton()
     private let checkingLabel: UILabel = UILabel()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .white
+        
         self.navigationItem.title = "친구 추가"
-        
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: navigationButton)
-        
-        [navigationButton, nicknameLabel, searchTextField, textDeleteButton, checkingLabel].forEach { view.addSubview($0) }
+
+        [navigationButton, nicknameLabel, searchTextField, textDeleteButton, friendSearchButton, checkingLabel].forEach { view.addSubview($0) }
         
         setupLabelLayout()
         setupTextFieldLayout()
@@ -32,6 +34,13 @@ class FriendshipViewController: UIViewController {
         configureLayout()
         
         searchTextField.becomeFirstResponder()
+        searchTextField.rx.text
+                   .map { $0 ?? "" } 
+                   .map { $0.isEmpty }
+                   .subscribe(onNext: { [weak self] isEmpty in
+                       self?.checkingLabel.textColor = isEmpty ? .clear : UIColor.allowedButtonColor
+                   })
+                   .disposed(by: disposeBag)
     }
     
     override func viewDidLayoutSubviews() {
@@ -54,17 +63,68 @@ class FriendshipViewController: UIViewController {
     }
     
     private func setupTextFieldLayout() {
-        
+        searchTextField.placeholder = "친구의 닉네임을 입력해주세요"
+        searchTextField.backgroundColor = .clear
     }
     
     private func setupButtonLayout() {
+        navigationButton.setTitle("완료", for: .normal)
+        navigationButton.setTitleColor(.systemBlue, for: .normal)
+        navigationButton.addTarget(self, action: #selector(navigationButtonTapped), for: .touchUpInside)
         
+        textDeleteButton.setBackgroundImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
+        textDeleteButton.tintColor = UIColor.textDeleteButtonColor
+        textDeleteButton.addTarget(self, action: #selector(textDeleteButtonTapped), for: .touchUpInside)
+        
+        friendSearchButton.setRooundedButton(title: "찾기",
+                                               titleSize: 12,
+                                               titleColor: .white,
+                                             backgroundColor: UIColor.checkRedButtonColor,
+                                               radius: 7)
+        friendSearchButton.addTarget(self, action: #selector(friendSearchButtonTapped), for: .touchUpInside)
+        
+    }
+    
+    @objc func navigationButtonTapped() {
+        self.navigationController?.popViewController(animated: false)
+    }
+    
+    @objc func textDeleteButtonTapped() {
+        searchTextField.text = String()
+    }
+    
+    @objc func friendSearchButtonTapped() {
+        // TODO: API 호출 need
     }
     
     private func configureLayout() {
         nicknameLabel.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).offset(81)
             make.leading.equalToSuperview().inset(20)
+        }
+        
+        searchTextField.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(110)
+            make.leading.equalToSuperview().inset(20)
+            make.width.equalTo(280)
+            make.height.equalTo(41)
+        }
+        
+        textDeleteButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(125)
+            make.leading.equalToSuperview().inset(282)
+        }
+        
+        friendSearchButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(118)
+            make.leading.equalToSuperview().inset(320)
+            make.width.equalTo(57)
+            make.height.equalTo(37)
+        }
+        
+        checkingLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(169)
+            make.leading.equalToSuperview().inset(19)
         }
     }
 }


### PR DESCRIPTION
# Summary & Issues
Closes #17 
- 친구 추가 화면 (FriendshipViewController) UI 구현
- textfield 입력값을 통한 API 연동 및 라벨 색상 변화 구현
- UserAPI에 추가적으로 닉네임을 통한 친구 조회를 구현했습니다. 
![스크린샷 2024-02-18 오후 7 57 51](https://github.com/GDSC-Wetox/Wetox-iOS/assets/82718756/bb64114b-5ac6-4259-afa7-568ebf8b81b5)
- ADD files 중 FriendshipAPI 관련 네트워크 모델은 아직 구현 중입니다. (해당 FriendshipVC에서는 활용되지 않습니다. 추후 AlertVC에서 호출될 예정입니다.) HTTP method 수정이 필요할 수 있습니다. 

### Contents 
<img width="250" src="https://github.com/GDSC-Wetox/Wetox-iOS/assets/82718756/fd75908e-3dca-478d-9382-e67402e05119">

### Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
