### PR TITLE
[FEAT] 배지 API 연동 구현 

### DIFF
--- a/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
+++ b/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
@@ -72,6 +72,10 @@
 		BF7209FA2B5F928D001D76CB /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = BF7209F92B5F928D001D76CB /* RxCocoa */; };
 		BF7209FC2B5F928D001D76CB /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = BF7209FB2B5F928D001D76CB /* RxRelay */; };
 		BF7209FE2B5F928D001D76CB /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BF7209FD2B5F928D001D76CB /* RxSwift */; };
+		BF8DA31F2B85E520001957C2 /* BadgeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8DA31E2B85E520001957C2 /* BadgeService.swift */; };
+		BF8DA3212B85E595001957C2 /* BadgeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8DA3202B85E595001957C2 /* BadgeAPI.swift */; };
+		BF8DA3262B85FF7E001957C2 /* BadgeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8DA3252B85FF7E001957C2 /* BadgeResponse.swift */; };
+		BF8DA3282B860691001957C2 /* BadgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8DA3272B860691001957C2 /* BadgeViewModel.swift */; };
 		BFB317A32B665744007F0A9A /* StrokeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB317A22B665744007F0A9A /* StrokeLabel.swift */; };
 		BFB317A52B6666AF007F0A9A /* TimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB317A42B6666AF007F0A9A /* TimeConverter.swift */; };
 		BFB317A82B666962007F0A9A /* ScreenTimeInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB317A72B666962007F0A9A /* ScreenTimeInputViewModel.swift */; };
@@ -155,6 +159,10 @@
 		BF7209EF2B5F8CCB001D76CB /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		BF7209F42B5F923F001D76CB /* FriendsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsCollectionViewCell.swift; sourceTree = "<group>"; };
 		BF7209F62B5F926B001D76CB /* CircularProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressBar.swift; sourceTree = "<group>"; };
+		BF8DA31E2B85E520001957C2 /* BadgeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeService.swift; sourceTree = "<group>"; };
+		BF8DA3202B85E595001957C2 /* BadgeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeAPI.swift; sourceTree = "<group>"; };
+		BF8DA3252B85FF7E001957C2 /* BadgeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeResponse.swift; sourceTree = "<group>"; };
+		BF8DA3272B860691001957C2 /* BadgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeViewModel.swift; sourceTree = "<group>"; };
 		BFB317A22B665744007F0A9A /* StrokeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrokeLabel.swift; sourceTree = "<group>"; };
 		BFB317A42B6666AF007F0A9A /* TimeConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeConverter.swift; sourceTree = "<group>"; };
 		BFB317A72B666962007F0A9A /* ScreenTimeInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeInputViewModel.swift; sourceTree = "<group>"; };
@@ -203,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				55A097A62B7CC6B400F1D43E /* NetworkErrorUtils.swift */,
+				BF8DA31D2B85E50F001957C2 /* Badge */,
 				55EC6D822B7DE8860018128D /* Friendship */,
 				BF7181DB2B7A2EA500ACEA0D /* User */,
 				BF7181D22B749EA800ACEA0D /* ScreenTime */,
@@ -232,6 +241,7 @@
 		554F273E2B638ECF0050B6D9 /* NetworkModel */ = {
 			isa = PBXGroup;
 			children = (
+				BF8DA3222B85FD77001957C2 /* Badge */,
 				55EC6D832B7DE88E0018128D /* Friendship */,
 				BF7181E02B7A2F6E00ACEA0D /* User */,
 				BF7181CF2B73588800ACEA0D /* ScreenTime */,
@@ -475,11 +485,29 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		BF8DA31D2B85E50F001957C2 /* Badge */ = {
+			isa = PBXGroup;
+			children = (
+				BF8DA31E2B85E520001957C2 /* BadgeService.swift */,
+				BF8DA3202B85E595001957C2 /* BadgeAPI.swift */,
+			);
+			path = Badge;
+			sourceTree = "<group>";
+		};
+		BF8DA3222B85FD77001957C2 /* Badge */ = {
+			isa = PBXGroup;
+			children = (
+				BF8DA3252B85FF7E001957C2 /* BadgeResponse.swift */,
+			);
+			path = Badge;
+			sourceTree = "<group>";
+		};
 		BFB317A62B666953007F0A9A /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
 				BFB317A72B666962007F0A9A /* ScreenTimeInputViewModel.swift */,
 				BF7181D92B78E4DD00ACEA0D /* MainViewModel.swift */,
+				BF8DA3272B860691001957C2 /* BadgeViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -644,6 +672,7 @@
 				554F27472B6391D80050B6D9 /* RegisterRequest.swift in Sources */,
 				BF7209F52B5F923F001D76CB /* FriendsCollectionViewCell.swift in Sources */,
 				55EC6D872B7DFC8A0018128D /* FriendshipAPI.swift in Sources */,
+				BF8DA3282B860691001957C2 /* BadgeViewModel.swift in Sources */,
 				554F27432B63908E0050B6D9 /* TokenResponse.swift in Sources */,
 				BF7209F02B5F8CCB001D76CB /* Color+Extension.swift in Sources */,
 				BFB317AC2B6693A4007F0A9A /* View+Extension.swift in Sources */,
@@ -670,6 +699,7 @@
 				558601982B6629A6007EA357 /* Const.swift in Sources */,
 				55EC6D8F2B7E07F10018128D /* getFriendRequestsListResponse.swift in Sources */,
 				554412902B608CA9001B8CBA /* LoginViewController.swift in Sources */,
+				BF8DA3212B85E595001957C2 /* BadgeAPI.swift in Sources */,
 				55EC6D852B7DFC7E0018128D /* FriendshipService.swift in Sources */,
 				5514CE642B65F891006B2700 /* MoyaLoggerPlugin.swift in Sources */,
 				BF7181DD2B7A2EB300ACEA0D /* UserService.swift in Sources */,
@@ -680,7 +710,9 @@
 				554F27492B6391E20050B6D9 /* RegisterResponse.swift in Sources */,
 				55EC6D812B7DE8530018128D /* FriendshipViewController.swift in Sources */,
 				BF7181DA2B78E4DD00ACEA0D /* MainViewModel.swift in Sources */,
+				BF8DA31F2B85E520001957C2 /* BadgeService.swift in Sources */,
 				BF7181D42B749EC400ACEA0D /* ScreenTimeService.swift in Sources */,
+				BF8DA3262B85FF7E001957C2 /* BadgeResponse.swift in Sources */,
 				557F3EA22B60983A007C7247 /* Button+Extension.swift in Sources */,
 				554F27412B638EE60050B6D9 /* TokenRequest.swift in Sources */,
 				5514CE602B65F721006B2700 /* AuthService.swift in Sources */,

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Badge/BadgeResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Badge/BadgeResponse.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 struct BadgeResponse: Codable {
-    var badgeList: [Badge]
+    let badgeList: [Badge]
 }
 
 struct Badge: Codable {
-    var badgeName: String
-    var rewardedDate: Date?
-    var rewarded: Bool
+    let badgeName: String
+    let rewardedDate: Date?
+    let rewarded: Bool
 }

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Badge/BadgeResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Badge/BadgeResponse.swift
@@ -1,0 +1,18 @@
+//
+//  BadgeResponse.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/21/24.
+//
+
+import Foundation
+
+struct BadgeResponse: Codable {
+    var badgeList: [Badge]
+}
+
+struct Badge: Codable {
+    var badgeName: String
+    var rewardedDate: Date?
+    var rewarded: Bool
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkService/Badge/BadgeAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/Badge/BadgeAPI.swift
@@ -1,0 +1,62 @@
+//
+//  BadgeAPI.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/21/24.
+//
+
+import UIKit
+import Moya
+import RxSwift
+import RxMoya
+
+class BadgeAPI {
+    
+    static let provider = MoyaProvider<BadgeService>(plugins: [MoyaLoggerPlugin()])
+    
+    static func getBadges() -> Observable<BadgeResponse> {
+        
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter().mapDateFormat())
+        
+        return provider.rx.request(.getBadges)
+            .map(BadgeResponse.self, using: decoder)
+            .asObservable()
+            .catch { error in
+                if let moyaError = error as? MoyaError {
+                    switch moyaError {
+                        case .statusCode(let response):
+                            print("HTTP Status Code: \(response.statusCode)")
+                        case .jsonMapping(let response):
+                            print("JSON Mapping Error for Response: \(response)")
+                        default:
+                            print("Other MoyaError: \(moyaError.localizedDescription)")
+                    }
+                }
+                return Observable.error(error)
+            }
+    }
+    
+    static func updateBadge() -> Observable<BadgeResponse> {
+        
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter().mapDateFormat())
+        
+        return provider.rx.request(.updateBadge)
+            .map(BadgeResponse.self, using: decoder)
+            .asObservable()
+            .catch { error in
+                if let moyaError = error as? MoyaError {
+                    switch moyaError {
+                        case .statusCode(let response):
+                            print("HTTP Status Code: \(response.statusCode)")
+                        case .jsonMapping(let response):
+                            print("JSON Mapping Error for Response: \(response)")
+                        default:
+                            print("Other MoyaError: \(moyaError.localizedDescription)")
+                    }
+                }
+                return Observable.error(error)
+            }
+    }
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkService/Badge/BadgeService.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/Badge/BadgeService.swift
@@ -1,0 +1,50 @@
+//
+//  BadgeService.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/21/24.
+//
+
+import Foundation
+import Moya
+
+enum BadgeService {
+    case getBadges
+    case updateBadge
+}
+
+extension BadgeService: TargetType {
+    var baseURL: URL {
+        return URL(string: Const.URL.baseURL)!
+    }
+
+    var path: String {
+        switch self {
+        case .getBadges, .updateBadge:
+            return "/badge"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .getBadges:
+            return .get
+        case .updateBadge:
+            return .post
+        }
+    }
+
+    var task: Task {
+        switch self {
+            case .getBadges, .updateBadge:
+                return .requestPlain
+        }
+    }
+
+    var headers: [String: String]? {
+        guard let accessToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) else {
+            return nil
+        }
+        return ["Content-Type": "application/json", "Authorization": "Bearer \(accessToken)"]
+    }
+}

--- a/Wetox-iOS/Wetox-iOS/View/Badge/BadgeView.swift
+++ b/Wetox-iOS/Wetox-iOS/View/Badge/BadgeView.swift
@@ -13,10 +13,16 @@ import RxCocoa
 
 class BadgeView: UIView {
     
+    private var badgeViewModel = BadgeViewModel()
+    private var disposeBag = DisposeBag()
+    private var rewardedBadgeNames: [String] = []
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .white
         configureCollectionView()
+        badgeViewModel.fetchBadges()
+        bindBadge()
     }
     
     required init?(coder: NSCoder) {
@@ -41,12 +47,12 @@ class BadgeView: UIView {
     }()
     
     private func configureCollectionView() {
-        backgroundColor = .white
         addSubview(badgeCollectionView)
         
         badgeCollectionView.snp.makeConstraints {
             $0.leading.top.trailing.bottom.equalToSuperview().inset(4)
         }
+        
     }
 }
 
@@ -76,5 +82,18 @@ extension BadgeView: UICollectionViewDataSource, UICollectionViewDelegate, UICol
         let availableWidth = collectionView.frame.width - widthPaddingSpace
         let availableHeight = collectionView.frame.height - heightPaddingSpace
         return CGSize(width: availableWidth / 3, height: availableHeight / 4)
+    }
+}
+
+extension BadgeView {
+    func bindBadge() {
+        badgeViewModel.rewardedBadgeNames
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] badgeNames in
+                self?.rewardedBadgeNames = badgeNames
+                print("rewardedBadgeNames: \(self?.rewardedBadgeNames)")
+                // TODO: UI 업데이트 구현 
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/Wetox-iOS/Wetox-iOS/View/DailyViewController/DailyView.swift
+++ b/Wetox-iOS/Wetox-iOS/View/DailyViewController/DailyView.swift
@@ -145,4 +145,16 @@ extension DailyView: UICollectionViewDataSource, UICollectionViewDelegateFlowLay
         let cellWidth = (collectionView.frame.width - 32) / 3
         return CGSize(width: cellWidth, height: cellWidth)
     }
+        
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        if indexPath.item == collectionView.numberOfItems(inSection: indexPath.section) - 1 {
+            let friendshipViewController = FriendshipViewController()
+            let navigationController = UINavigationController(rootViewController: friendshipViewController)
+            navigationController.modalPresentationStyle = .fullScreen
+            if let viewController = self.findViewController() {
+                viewController.present(navigationController, animated: true)
+            }
+        }
+    }
 }

--- a/Wetox-iOS/Wetox-iOS/ViewModel/BadgeViewModel.swift
+++ b/Wetox-iOS/Wetox-iOS/ViewModel/BadgeViewModel.swift
@@ -1,0 +1,70 @@
+//
+//  BadgeViewModel.swift
+//  Wetox-iOS
+//
+//  Created by Lena on 2/21/24.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class BadgeViewModel {
+    
+    // MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private let badgeAPI = BadgeAPI.self
+    
+    // Observables exposed to the view
+    let badgeList: BehaviorSubject<[Badge]> = BehaviorSubject(value: [])
+    let rewardedBadgeNames: BehaviorSubject<[String]> = BehaviorSubject(value: [])
+    let isLoading: BehaviorSubject<Bool> = BehaviorSubject(value: false)
+    let error: BehaviorSubject<String?> = BehaviorSubject(value: nil)
+    
+    // MARK: - API Methods
+    
+    func fetchBadges() {
+        isLoading.onNext(true)
+        badgeAPI.getBadges()
+            .observe(on: MainScheduler.instance)
+            .subscribe { [weak self] badgeResponse in
+                self?.isLoading.onNext(false)
+                
+                // true인 badgeName을 추출
+                let rewardedBadges = badgeResponse.badgeList.filter { $0.rewarded }
+                let badgeNames = rewardedBadges.map { $0.badgeName }
+                
+                // 필터링된 배지 이름을 rewardedBadgeNames BehaviorSubject에 전달
+                self?.rewardedBadgeNames.onNext(badgeNames)
+                
+                // 전체 배지 리스트 업데이트
+                self?.badgeList.onNext(badgeResponse.badgeList)
+                
+                // 디버깅을 위한 출력
+                print("Rewarded Badge Names: \(badgeNames)")
+            } onError: { [weak self] error in
+                self?.isLoading.onNext(false)
+                self?.error.onNext(error.localizedDescription)
+            }.disposed(by: disposeBag)
+    }
+    
+    func updateBadge() {
+        isLoading.onNext(true)
+        badgeAPI.updateBadge()
+            .observe(on: MainScheduler.instance)
+            .subscribe { [weak self] badgeResponse in
+                self?.isLoading.onNext(false)
+                print("updateBadge의 badgeResponse: \(badgeResponse.badgeList)")
+                self?.badgeList.onNext(badgeResponse.badgeList)
+            } onError: { [weak self] error in
+                self?.isLoading.onNext(false)
+                self?.error.onNext(error.localizedDescription)
+            }.disposed(by: disposeBag)
+    }
+    
+    // MARK: - Initialization
+    
+    init() {
+        fetchBadges()
+    }
+}


### PR DESCRIPTION
# Summary & Issues

<!-- 작업 내용 요약 및 이슈 번호 작성해주세요 -->
배지 API 연동 


### Contents 
<!-- 작업내용을 상세하게 작성해주세요 / Screen Capture가 있다면 첨부해주세요 -->
- Badge API 연동 구현 
    - 엔드포인트 `/badge` 의 `.post`, `.get` API 연동을 구현하였습니다. 
    - Date는 `nil`일 수 있어 옵셔널로 선언하였습니다.  <br>

- BadgeViewModel 구현 
    - `BadgeResponse`의 응답 중 `rewarded` 값이 `true`인 경우만 필터링하여 받아올 수 있도록 구현하였습니다. 
    - BadgeView가 UIView라, 이에 대한 BadgeViewModel을 구현하는 것이 적합한 방법은 아닌 것으로 보입니다. 이에 대해서 구조에 대한 부분을 다시 한번 논의해보면 좋을 것 같습니다. 


### Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
