### PR TITLE
[FEAT] AIImageGeneration API 연동 

### DIFF
--- a/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
+++ b/Wetox-iOS/Wetox-iOS.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		554F27492B6391E20050B6D9 /* RegisterResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554F27482B6391E20050B6D9 /* RegisterResponse.swift */; };
 		555C80B62B866560003BEA55 /* NicknameValidRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555C80B52B866560003BEA55 /* NicknameValidRequest.swift */; };
 		555C80B82B86656D003BEA55 /* NicknameValidResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555C80B72B86656D003BEA55 /* NicknameValidResponse.swift */; };
+		555C80BA2B867BEB003BEA55 /* AIProfileImageResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555C80B92B867BEB003BEA55 /* AIProfileImageResponse.swift */; };
 		556AA2D02B6A3B2B00F2AE79 /* TextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556AA2CF2B6A3B2B00F2AE79 /* TextField+Extension.swift */; };
 		556C12912B834C5D0000797B /* AlertTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 556C12902B834C5D0000797B /* AlertTableViewCell.swift */; };
 		557926412B86052F004A4443 /* RegisterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557926402B86052F004A4443 /* RegisterService.swift */; };
@@ -117,6 +118,7 @@
 		554F27482B6391E20050B6D9 /* RegisterResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterResponse.swift; sourceTree = "<group>"; };
 		555C80B52B866560003BEA55 /* NicknameValidRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameValidRequest.swift; sourceTree = "<group>"; };
 		555C80B72B86656D003BEA55 /* NicknameValidResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameValidResponse.swift; sourceTree = "<group>"; };
+		555C80B92B867BEB003BEA55 /* AIProfileImageResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProfileImageResponse.swift; sourceTree = "<group>"; };
 		556AA2CF2B6A3B2B00F2AE79 /* TextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextField+Extension.swift"; sourceTree = "<group>"; };
 		556C12902B834C5D0000797B /* AlertTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertTableViewCell.swift; sourceTree = "<group>"; };
 		557926402B86052F004A4443 /* RegisterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterService.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 		5579263B2B8602B1004A4443 /* AIProfile */ = {
 			isa = PBXGroup;
 			children = (
+				555C80B92B867BEB003BEA55 /* AIProfileImageResponse.swift */,
 			);
 			path = AIProfile;
 			sourceTree = "<group>";
@@ -753,6 +756,7 @@
 				554412902B608CA9001B8CBA /* LoginViewController.swift in Sources */,
 				BF8DA3212B85E595001957C2 /* BadgeAPI.swift in Sources */,
 				55EC6D852B7DFC7E0018128D /* FriendshipService.swift in Sources */,
+				555C80BA2B867BEB003BEA55 /* AIProfileImageResponse.swift in Sources */,
 				5514CE642B65F891006B2700 /* MoyaLoggerPlugin.swift in Sources */,
 				BF7181DD2B7A2EB300ACEA0D /* UserService.swift in Sources */,
 				BF7209F72B5F926B001D76CB /* CircularProgressBar.swift in Sources */,

--- a/Wetox-iOS/Wetox-iOS/Extension/Color+Extension.swift
+++ b/Wetox-iOS/Wetox-iOS/Extension/Color+Extension.swift
@@ -99,14 +99,14 @@ extension UIColor {
     
     // MARK: - Segmented Control Colors
     static var segmentedBackgroundGrayColor: UIColor {
-        return UIColor(hexCode: "0xE8E8E8")
+        return UIColor(hexCode: "0x404040", alpha: 0.12)
     }
     
     // MARK: - Tint Colors (label / image etc)
     
     /// 404040, alpha: 0.64
     static var unselectedTintColor: UIColor {
-        return UIColor(hexCode: "0x404040", alpha: 0.64)
+        return UIColor(hexCode: "0x404040", alpha: 0.28)
     }
     
     static var selectedTintColor: UIColor {

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Register/AIProfile/AIProfileImageResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Register/AIProfile/AIProfileImageResponse.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct AIProfileImageResponse: Codable {
-    let imageData: Data
+    
 }

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Register/AIProfile/AIProfileImageResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Register/AIProfile/AIProfileImageResponse.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+struct AIProfileImageResponse: Codable {
+    let imageData: Data
+}

--- a/Wetox-iOS/Wetox-iOS/NetworkModel/Register/AIProfile/AIProfileImageResponse.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkModel/Register/AIProfile/AIProfileImageResponse.swift
@@ -1,0 +1,8 @@
+//
+//  AIProfileImageResponse.swift
+//  Wetox-iOS
+//
+//  Created by 김소현 on 2/22/24.
+//
+
+import Foundation

--- a/Wetox-iOS/Wetox-iOS/NetworkService/Register/RegisterAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/Register/RegisterAPI.swift
@@ -35,4 +35,26 @@ public class RegisterAPI {
                 return Observable.error(error)
             }
     }
+    
+    static func getAIProfileImage() -> Observable<AIProfileImageResponse> {
+        // TODO: Decoding 방식 수정하기 
+        let decoder = JSONDecoder()
+        
+        return registerProvider.rx.request(.getAIImage)
+            .map(AIProfileImageResponse.self, using: decoder)
+            .asObservable()
+            .catch { error in
+                if let moyaError = error as? MoyaError {
+                    switch moyaError {
+                    case .statusCode(let response):
+                        print("HTTP Status Code: \(response.statusCode)")
+                    case .jsonMapping(let response):
+                        print("JSON Mapping Error for Response: \(response)")
+                    default:
+                        print("Other MoyaError: \(moyaError.localizedDescription)")
+                    }
+                }
+                return Observable.error(error)
+            }
+    }
 }

--- a/Wetox-iOS/Wetox-iOS/NetworkService/Register/RegisterAPI.swift
+++ b/Wetox-iOS/Wetox-iOS/NetworkService/Register/RegisterAPI.swift
@@ -36,25 +36,24 @@ public class RegisterAPI {
             }
     }
     
-    static func getAIProfileImage() -> Observable<AIProfileImageResponse> {
-        // TODO: Decoding 방식 수정하기 
-        let decoder = JSONDecoder()
-        
-        return registerProvider.rx.request(.getAIImage)
-            .map(AIProfileImageResponse.self, using: decoder)
-            .asObservable()
-            .catch { error in
-                if let moyaError = error as? MoyaError {
-                    switch moyaError {
-                    case .statusCode(let response):
-                        print("HTTP Status Code: \(response.statusCode)")
-                    case .jsonMapping(let response):
-                        print("JSON Mapping Error for Response: \(response)")
-                    default:
-                        print("Other MoyaError: \(moyaError.localizedDescription)")
-                    }
+    static func getAIProfileImage() -> Observable<Data> {
+            return registerProvider.rx.request(.getAIImage)
+                .map { response -> Data in
+                    print("response")
+                    print(response.data)
+                    return response.data
                 }
-                return Observable.error(error)
-            }
-    }
+                .asObservable()
+                .catch { error in
+                    if let moyaError = error as? MoyaError {
+                        switch moyaError {
+                        case .statusCode(let response):
+                            print("HTTP Status Code: \(response.statusCode)")
+                        default:
+                            print("Other MoyaError: \(moyaError.localizedDescription)")
+                        }
+                    }
+                    return Observable.error(error)
+                }
+        }
 }

--- a/Wetox-iOS/Wetox-iOS/View/AlertViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/AlertViewController.swift
@@ -49,7 +49,7 @@ class AlertViewController: UIViewController {
     }
     
     @objc func navigationButtonTapped() {
-        self.navigationController?.popViewController(animated: false)
+        dismiss(animated: true)
     }
 }
 

--- a/Wetox-iOS/Wetox-iOS/View/ProfileSettingViewContorller.swift
+++ b/Wetox-iOS/Wetox-iOS/View/ProfileSettingViewContorller.swift
@@ -107,7 +107,8 @@ class ProfileSettingViewContorller: UIViewController {
     }
 
     @objc func AIGenerationButtonTapped() {
-        // TODO: AI 생성 API 연결
+         fetchAIProfileImage()
+//        profileImageView.image = UIImage(named: <#T##String#>)
     }
     
     @objc func navigationButtonTapped() {
@@ -196,15 +197,24 @@ extension ProfileSettingViewContorller {
         alertController.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
         self.present(alertController, animated: true, completion: nil)
     }
-}
-
-extension ProfileSettingViewContorller {
+    
+    func fetchAIProfileImage() {
+        RegisterAPI.getAIProfileImage()
+            .subscribe(onNext: { response in
+                print("response")
+                print(response)
+            }, onError: { error in
+                print("Error fetching AI profile image: \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+    }
+    
     func registerWithAPI(registerRequest: RegisterRequest, profileImage: UIImage?) {
         AuthAPI.register(registerRequest: registerRequest, profileImage: profileImage)
             .subscribe(onNext: { registerResponse in
                 UserDefaults.standard.set(registerResponse.accessToken, forKey: Const.UserDefaultsKey.accessToken)
                 print("accessToken 값 입니다. ")
-                print(registerResponse.accessToken) 
+                print(registerResponse.accessToken)
                 self.navigationController?.pushViewController(RootViewController(), animated: true)
                 print("회원가입 성공: \(registerResponse)")
             }, onError: { error in

--- a/Wetox-iOS/Wetox-iOS/View/ProfileSettingViewContorller.swift
+++ b/Wetox-iOS/Wetox-iOS/View/ProfileSettingViewContorller.swift
@@ -108,7 +108,6 @@ class ProfileSettingViewContorller: UIViewController {
 
     @objc func AIGenerationButtonTapped() {
          fetchAIProfileImage()
-//        profileImageView.image = UIImage(named: <#T##String#>)
     }
     
     @objc func navigationButtonTapped() {
@@ -116,10 +115,9 @@ class ProfileSettingViewContorller: UIViewController {
         let deviceToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.deviceToken) ?? String()
         let openId = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.openId) ?? String()
 
-        // TODO: AI 프로필 api 연동
         // TODO: oauthProvider setting 추후 수정하기
         let registerRequest = RegisterRequest(nickname: nickname, oauthProvider: "KAKAO", openId: openId, deviceToken: deviceToken)
-        registerWithAPI(registerRequest: registerRequest, profileImage: UIImage(named: "default-profile-icon"))
+        registerWithAPI(registerRequest: registerRequest, profileImage: self.profileImageView.image)
     }
     
     private func configureLayout() {
@@ -200,11 +198,15 @@ extension ProfileSettingViewContorller {
     
     func fetchAIProfileImage() {
         RegisterAPI.getAIProfileImage()
-            .subscribe(onNext: { response in
-                print("response")
-                print(response)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { imageData in
+                guard let image = UIImage(data: imageData) else {
+                    print("Failed to convert data to image")
+                    return
+                }
+                self.profileImageView.image = image
             }, onError: { error in
-                print("Error fetching AI profile image: \(error.localizedDescription)")
+                print("Error: \(error.localizedDescription)")
             })
             .disposed(by: disposeBag)
     }

--- a/Wetox-iOS/Wetox-iOS/View/RootView/RootViewController.swift
+++ b/Wetox-iOS/Wetox-iOS/View/RootView/RootViewController.swift
@@ -28,8 +28,7 @@ class RootViewController: UIViewController {
         
         segmentedControl.frame = CGRectMake(0, 0, 180, 36)
         segmentedControl.layer.cornerRadius = 5.0
-        segmentedControl.backgroundColor = .segmentedBackgroundGrayColor
-        segmentedControl.tintColor = .gray
+        segmentedControl.tintColor = .segmentedBackgroundGrayColor
         return segmentedControl
     }()
     
@@ -41,6 +40,7 @@ class RootViewController: UIViewController {
         button.tintColor = .unselectedTintColor
         button.setImage(image, for: .normal)
         button.contentMode = .scaleToFill
+        button.addTarget(self, action: #selector(alarmButtonTapped), for: .touchUpInside)
         return button
         
     }()
@@ -54,7 +54,6 @@ class RootViewController: UIViewController {
         button.setImage(image, for: .normal)
         button.contentMode = .scaleToFill
         return button
-        
     }()
     
     override func viewDidLoad() {
@@ -94,10 +93,17 @@ class RootViewController: UIViewController {
         }
         
         alarmButton.snp.makeConstraints {
-            $0.trailing.equalTo(settingButton.snp.leading).offset(Constants.Padding.narrowPadding)
+            $0.trailing.equalTo(settingButton.snp.leading).offset(Constants.Padding.defaultPadding / 10)
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             $0.width.height.equalTo(42)
         }
+    }
+    
+    @objc func alarmButtonTapped() {
+        let alertViewController = AlertViewController()
+        let navigationController = UINavigationController(rootViewController: alertViewController)
+        navigationController.modalPresentationStyle = .fullScreen
+        present(navigationController, animated: true)
     }
 
     @objc func tappedSegmentedControl(_ segmentedControl: UISegmentedControl) {


### PR DESCRIPTION
# Summary & Issues
Closes #25 

### Contents 
- AIProfile API 연동 구현 및 Register Flow 구현 완료
- RootVC와 하위 뷰 컨트롤러 간 연결 구현 완료
- RootVC UIButton Color 변경 (색상이 옅어졌고, 패딩 값을 변경했습니다.)

### Issues
- 서버로부터 바로 PNG 데이터를 받아오는 형식으로 구현되어, AIProfileImageResponse 구조체가 필요하지 않습니다. 
- 폴더 구조를 변경하고자 하는데, conflict 발생이 우려되어 현재 빈 struct를 담아두는 것으로 commit 해두었습니다. 
- 브랜치 간 충돌이 무관할 경우, 해당 폴더와 하위 파일을 삭제하여 수정하겠습니다. 

<img width="250" src="https://github.com/GDSC-Wetox/Wetox-iOS/assets/82718756/ba990acc-9ccb-4485-976c-5ab66de8575a">
<img width="250" src="https://github.com/GDSC-Wetox/Wetox-iOS/assets/82718756/a04f9452-42e5-4552-bb0d-65dce109ea3d">

### Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
